### PR TITLE
Fix nil pointer dereference when affinity is not configured

### DIFF
--- a/app/k8s/k8s.go
+++ b/app/k8s/k8s.go
@@ -157,7 +157,6 @@ func crateDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Con
 		},
 	}
 	// Affinity
-	fmt.Println(*params.DeploymentAffinity)
 	if params.DeploymentAffinity != nil {
 		deployment.Spec.Template.Spec.Affinity = makeAffinityParams(params.DeploymentAffinity)
 	}

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -136,8 +136,6 @@ func init() {
 	PriorityClassName = config.PriorityClassName
 	Timeout = config.Timeout
 	EcrTags = config.EcrTags
-	fmt.Println("debug")
-	fmt.Println(config.Affinity)
 	DeploymentAffinity = config.Affinity
 }
 


### PR DESCRIPTION
## Summary

- Remove debug `fmt.Println` statements that cause a nil pointer dereference (panic) when `affinity` is not set in `params.yaml`
- The existing nil check (`if params.DeploymentAffinity != nil`) works correctly once the dereference before it is removed

## Root Cause

In `k8s.go:160`, `fmt.Println(*params.DeploymentAffinity)` dereferences the pointer **before** the nil check on line 161. When a user does not configure `affinity` in `params.yaml`, `DeploymentAffinity` is nil, causing a SIGSEGV panic.

## Changes

- `app/k8s/k8s.go`: Remove `fmt.Println(*params.DeploymentAffinity)` (line 160)
- `app/params/params.go`: Remove `fmt.Println("debug")` and `fmt.Println(config.Affinity)` (lines 139-140)

## Test Plan

- [x] Verified panic reproduction on `add_affinity_support` branch with `params.yaml` without `affinity` field (SIGSEGV at k8s.go:160)
- [x] Verified fix on `fix/affinity-nil-panic` branch with same `params.yaml` — test passes (Namespace, Deployment, Service created successfully)
- [x] Tested on local kind cluster (`prism-test-cluster`)