### PR TITLE
Add support for node affinity and pod anti-affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ $ make run-delete
 | `istioProxyCpu`               | CPU request for Istio                     | `"500m"`                       | No       |
 | `istioProxyMemory`            | Memory request for Istio                  | `"512Mi"`                      | No       |
 | `priorityClassName`           | Value of priorityClassName                | -                              | No       |
+| `nodeAffinity`                | Node affinity match expressions (key, operator, values). Operators: In, NotIn, Exists, DoesNotExist, Gt, Lt | -                              | No       |
+| `podAntiAffinityTopologyKey`  | Topology key for pod anti-affinity (e.g., `kubernetes.io/hostname`). Prevents multiple pods of the same service from running on the same topology | -                              | No       |
 | `ecrTags`                     | Pairs of ECR tag                          | -                              | No       |
 
 sample:
@@ -72,12 +74,20 @@ microserviceNamespace: "sample"
 prismMockSuffix: "-prism-mock"
 istioMode: false
 priorityClassName: "high-priority"
+nodeAffinity:
+  - key: "karpenter.sh/nodepool"
+    operator: "In"
+    values:
+      - "default"
+podAntiAffinityTopologyKey: "kubernetes.io/hostname"
 ecrTags:
   - key: "CostEnv"
     value: "stg"
   - key: "CostService"
     value: "pet-store"
 ```
+
+Note: `podAntiAffinityTopologyKey` uses `requiredDuringSchedulingIgnoredDuringExecution` with the `app` label of the deployed service as the label selector. This means it prevents multiple pods of the same Prism mock service from being scheduled on the same topology (e.g., same node).
 
 # For developers
 ## Testing

--- a/app/k8s/k8s.go
+++ b/app/k8s/k8s.go
@@ -153,6 +153,8 @@ func crateDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Con
 		},
 	}
 
+	deployment.Spec.Template.Spec.Affinity = buildAffinity(resourceName)
+
 	if isTest {
 		// to get image from local
 		deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullNever
@@ -176,6 +178,58 @@ func crateDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Con
 		log.Println("[INFO] Deployment is created successfully")
 	}
 	return nil
+}
+
+func buildAffinity(resourceName string) *corev1.Affinity {
+	hasNodeAffinity := len(params.NodeAffinityMatchExpressions) > 0
+	hasPodAntiAffinity := params.PodAntiAffinityTopologyKey != ""
+
+	if !hasNodeAffinity && !hasPodAntiAffinity {
+		return nil
+	}
+
+	affinity := &corev1.Affinity{}
+
+	if hasNodeAffinity {
+		matchExpressions := make([]corev1.NodeSelectorRequirement, 0, len(params.NodeAffinityMatchExpressions))
+		for _, expr := range params.NodeAffinityMatchExpressions {
+			matchExpressions = append(matchExpressions, corev1.NodeSelectorRequirement{
+				Key:      expr.Key,
+				Operator: corev1.NodeSelectorOperator(expr.Operator),
+				Values:   expr.Values,
+			})
+		}
+		affinity.NodeAffinity = &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: matchExpressions,
+					},
+				},
+			},
+		}
+	}
+
+	if hasPodAntiAffinity {
+		affinity.PodAntiAffinity = &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{resourceName},
+							},
+						},
+					},
+					TopologyKey: params.PodAntiAffinityTopologyKey,
+				},
+			},
+		}
+	}
+
+	return affinity
 }
 
 func createService(ctx context.Context, k8sClientSet *kubernetes.Clientset, namespaceName, resourceName string) error {

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -22,11 +22,17 @@ const (
 )
 
 var (
-	errEmptyParameter           = errors.New("empty parameter found")
-	errUnsupportedParameterType = errors.New("unsupported parameter type")
-	errFailedToOpenConfigFile   = errors.New("failed to open config file")
-	errFailedToDecodeConfigFile = errors.New("failed to decode config file")
+	errEmptyParameter                = errors.New("empty parameter found")
+	errUnsupportedParameterType      = errors.New("unsupported parameter type")
+	errFailedToOpenConfigFile        = errors.New("failed to open config file")
+	errFailedToDecodeConfigFile      = errors.New("failed to decode config file")
+	errInvalidNodeSelectorOperator   = errors.New("invalid node selector operator")
 )
+
+var validNodeSelectorOperators = map[string]bool{
+	"In": true, "NotIn": true, "Exists": true,
+	"DoesNotExist": true, "Gt": true, "Lt": true,
+}
 
 var (
 	// required parameters
@@ -41,8 +47,10 @@ var (
 	IstioMode         bool
 	IstioProxyCPU     string
 	IstioProxyMemory  string
-	PriorityClassName string
-	EcrTags           []ECRTag
+	PriorityClassName            string
+	NodeAffinityMatchExpressions []NodeAffinityMatchExpression
+	PodAntiAffinityTopologyKey   string
+	EcrTags                      []ECRTag
 )
 
 type Config struct {
@@ -56,8 +64,16 @@ type Config struct {
 	IstioMode             bool          `yaml:"istioMode"`
 	IstioProxyCPU         string        `yaml:"istioProxyCpu"`
 	IstioProxyMemory      string        `yaml:"istioProxyMemory"`
-	PriorityClassName     string        `yaml:"priorityClassName"`
-	EcrTags               []ECRTag      `yaml:"ecrTags"`
+	PriorityClassName            string                       `yaml:"priorityClassName"`
+	NodeAffinityMatchExpressions []NodeAffinityMatchExpression `yaml:"nodeAffinity"`
+	PodAntiAffinityTopologyKey   string                       `yaml:"podAntiAffinityTopologyKey"`
+	EcrTags                      []ECRTag                     `yaml:"ecrTags"`
+}
+
+type NodeAffinityMatchExpression struct {
+	Key      string   `yaml:"key"`
+	Operator string   `yaml:"operator"`
+	Values   []string `yaml:"values"`
 }
 
 type ECRTag struct {
@@ -110,6 +126,8 @@ func init() {
 		IstioProxyMemory = config.IstioProxyMemory
 	}
 	PriorityClassName = config.PriorityClassName
+	NodeAffinityMatchExpressions = config.NodeAffinityMatchExpressions
+	PodAntiAffinityTopologyKey = config.PodAntiAffinityTopologyKey
 	EcrTags = config.EcrTags
 }
 
@@ -160,5 +178,12 @@ func ValidateParams() error {
 			return xerrors.Errorf("%w: %s", errUnsupportedParameterType, name)
 		}
 	}
+
+	for _, expr := range NodeAffinityMatchExpressions {
+		if !validNodeSelectorOperators[expr.Operator] {
+			return xerrors.Errorf("%w: %s", errInvalidNodeSelectorOperator, expr.Operator)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
close https://github.com/gold-kou/prism-in-k8s/issues/8

- Introduced new parameters for node affinity match expressions and pod anti-affinity topology key in params.
- Updated the deployment creation logic to apply affinity settings.
- Enhanced README with details on new configuration options.