### PR TITLE
Fix TestDeleteIstioResources to actually test deletion

### DIFF
--- a/app/istio/istio_test.go
+++ b/app/istio/istio_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"istio.io/client-go/pkg/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -71,6 +72,7 @@ func TestDeleteIstioResources(t *testing.T) {
 	// verify
 	_, err = istioClientSet.NetworkingV1alpha3().VirtualServices(testNamespaceName).Get(ctx, testResourceName, metav1.GetOptions{})
 	assert.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err))
 
 	// clean up
 	err = testutil.DeleteNamespace(ctx, k8sClientSet, testNamespaceName)

--- a/app/istio/istio_test.go
+++ b/app/istio/istio_test.go
@@ -65,10 +65,12 @@ func TestDeleteIstioResources(t *testing.T) {
 	require.NoError(t, err)
 
 	// test target
-	err = istio.CreateIstioResources(ctx, kubeconfig, testNamespaceName, testResourceName)
+	err = istio.DeleteIstioResources(ctx, kubeconfig, testNamespaceName, testResourceName)
 	assert.NoError(t, err)
 
-	// skip verify to reduce test time
+	// verify
+	_, err = istioClientSet.NetworkingV1alpha3().VirtualServices(testNamespaceName).Get(ctx, testResourceName, metav1.GetOptions{})
+	assert.Error(t, err)
 
 	// clean up
 	err = testutil.DeleteNamespace(ctx, k8sClientSet, testNamespaceName)


### PR DESCRIPTION
## Summary
- Fix `TestDeleteIstioResources` which was calling `CreateIstioResources` instead of `DeleteIstioResources`
- Add verification that the VirtualService is actually deleted after the call

## Test plan
- [ ] Verify test logic correctness by reviewing the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)