### PR TITLE
Fix typo: crateDeployment -> createDeployment

### DIFF
--- a/app/k8s/k8s.go
+++ b/app/k8s/k8s.go
@@ -50,7 +50,7 @@ func CreateK8sResources(ctx context.Context, awsAccountID string, awsConfig aws.
 		return xerrors.Errorf("%w: %w", errFailedToCreateNameSpace, err)
 	}
 
-	err = crateDeployment(ctx, awsAccountID, awsConfig, k8sClientSet, namespaceName, resourceName, istioMode, isTest)
+	err = createDeployment(ctx, awsAccountID, awsConfig, k8sClientSet, namespaceName, resourceName, istioMode, isTest)
 	if err != nil {
 		return xerrors.Errorf("%w: %w", errFailedToCreateDeployment, err)
 	}
@@ -103,7 +103,7 @@ func createNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, na
 	return nil
 }
 
-func crateDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Config, k8sClientSet *kubernetes.Clientset, namespaceName, resourceName string, istioMode, isTest bool) error {
+func createDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Config, k8sClientSet *kubernetes.Clientset, namespaceName, resourceName string, istioMode, isTest bool) error {
 	// Prism image
 	prismImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", awsAccountID, awsConfig.Region, resourceName)
 	if isTest {


### PR DESCRIPTION
## Summary
- Fix function name typo `crateDeployment` to `createDeployment` in `app/k8s/k8s.go`

## Test plan
- [ ] `go build ./...` passes
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)