### PR TITLE
Migrate from deprecated protobuf package

### DIFF
--- a/app/istio/istio.go
+++ b/app/istio/istio.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/golang/protobuf/ptypes/duration"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"github.com/pingcap/errors"
 	"golang.org/x/xerrors"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
@@ -64,7 +64,7 @@ func CreateIstioResources(ctx context.Context, kubeconfig *restclient.Config, na
 								Value: defaultDelayPercentage,
 							},
 							HttpDelayType: &networkingv1alpha3.HTTPFaultInjection_Delay_FixedDelay{
-								FixedDelay: &duration.Duration{Nanos: int32(defaultDelayNanos)}, // 100ms
+								FixedDelay: &durationpb.Duration{Nanos: int32(defaultDelayNanos)}, // 100ms
 							},
 						},
 					},

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.24
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.1
-	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/pingcap/errors v0.11.4
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
+	google.golang.org/protobuf v1.35.1
 	gopkg.in/yaml.v2 v2.4.0
 	istio.io/api v1.22.3-0.20240703105953-437a88321a16
 	istio.io/client-go v1.22.3
@@ -38,6 +38,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
@@ -58,7 +59,6 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241104194629-dd2ea8efbc28 // indirect
-	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect


### PR DESCRIPTION
## Summary
- Replace deprecated `github.com/golang/protobuf/ptypes/duration` with `google.golang.org/protobuf/types/known/durationpb`

## Test plan
- [ ] `go build ./...` passes
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)