### PR TITLE
Remove util package, use k8s.io/utils/ptr instead

### DIFF
--- a/app/k8s/k8s.go
+++ b/app/k8s/k8s.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gold-kou/prism-in-k8s/app/params"
-	"github.com/gold-kou/prism-in-k8s/app/util"
+	"k8s.io/utils/ptr"
 	"github.com/pingcap/errors"
 	"golang.org/x/xerrors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -116,7 +116,7 @@ func crateDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Con
 			Name: resourceName,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: util.Int32Ptr(1),
+			Replicas: ptr.To[int32](1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": resourceName,

--- a/app/testutil/helper.go
+++ b/app/testutil/helper.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/gold-kou/prism-in-k8s/app/params"
-	"github.com/gold-kou/prism-in-k8s/app/util"
+	"k8s.io/utils/ptr"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"istio.io/client-go/pkg/clientset/versioned"
@@ -41,7 +41,7 @@ func CreateDeployment(ctx context.Context, clientset *kubernetes.Clientset, name
 			Name: name,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: util.Int32Ptr(1),
+			Replicas: ptr.To[int32](1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": name,

--- a/app/util/util.go
+++ b/app/util/util.go
@@ -1,6 +1,0 @@
-package util
-
-func Int32Ptr(i int) *int32 {
-	u := int32(i)
-	return &u
-}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/api v0.30.2
 	k8s.io/apimachinery v0.30.2
 	k8s.io/client-go v0.30.2
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 )
 
 require (
@@ -63,7 +64,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect


### PR DESCRIPTION
## Summary
- Remove `app/util/util.go` which only contained `Int32Ptr()`
- Replace with `k8s.io/utils/ptr.To[int32]()` from the standard K8s utility library

## Test plan
- [ ] `go build ./...` passes
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)