### PR TITLE
Unify error handling with stdlib fmt.Errorf

### DIFF
--- a/app/istio/istio.go
+++ b/app/istio/istio.go
@@ -2,14 +2,15 @@ package istio
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 
 	"github.com/golang/protobuf/ptypes/duration"
-	"github.com/pingcap/errors"
-	"golang.org/x/xerrors"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"istio.io/client-go/pkg/clientset/versioned"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 )
@@ -29,7 +30,7 @@ func CreateIstioResources(ctx context.Context, kubeconfig *restclient.Config, na
 	// Istio clientset
 	istioClientSet, err := versioned.NewForConfig(kubeconfig)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateIstioClient, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateIstioClient, err)
 	}
 
 	// VirtualService
@@ -91,8 +92,8 @@ func CreateIstioResources(ctx context.Context, kubeconfig *restclient.Config, na
 	}
 	_, err = istioClientSet.NetworkingV1alpha3().VirtualServices(namespaceName).Create(ctx, virtualService, metav1.CreateOptions{})
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return xerrors.Errorf("%w: %w", errFailedToCreateVirtualService, err)
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("%w: %w", errFailedToCreateVirtualService, err)
 		}
 		log.Println("[WARN] The VirtualService already exists")
 	} else {
@@ -105,14 +106,14 @@ func DeleteIstioResources(ctx context.Context, kubeconfig *restclient.Config, na
 	// Istio clientset
 	istioClientSet, err := versioned.NewForConfig(kubeconfig)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateIstioClient, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateIstioClient, err)
 	}
 	log.Println("[INFO] Clientset of istio set up successfully")
 
 	err = istioClientSet.NetworkingV1alpha3().VirtualServices(namespaceName).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return xerrors.Errorf("%w: %w", errFailedToDeleteVirtualService, err)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("%w: %w", errFailedToDeleteVirtualService, err)
 		}
 		log.Println("[WARN] The VirtualService is not found")
 	} else {

--- a/app/k8s/k8s.go
+++ b/app/k8s/k8s.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -10,10 +11,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gold-kou/prism-in-k8s/app/params"
 	"github.com/gold-kou/prism-in-k8s/app/util"
-	"github.com/pingcap/errors"
-	"golang.org/x/xerrors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -35,29 +35,31 @@ var (
 	errFailedToDeleteNameSpace  = errors.New("failed to delete namespace")
 	errFailedToDeleteDeployment = errors.New("failed to delete deployment")
 	errFailedToDeleteService    = errors.New("failed to delete service")
-	errFailedToListPods         = errors.New("failed to list pods")
-	errFailedToGetLatestVersion = errors.New("failed to get latest version")
+	errFailedToListPods           = errors.New("failed to list pods")
+	errFailedToGetLatestVersion   = errors.New("failed to get latest version")
+	errInvalidVersionFormat       = errors.New("invalid version format")
+	errInvalidNumberInVersion     = errors.New("invalid number in version")
 )
 
 func CreateK8sResources(ctx context.Context, awsAccountID string, awsConfig aws.Config, kubeconfig *restclient.Config, namespaceName, resourceName string, istioMode, isTest bool) error {
 	k8sClientSet, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateClientSet, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateClientSet, err)
 	}
 
 	err = createNamespace(ctx, k8sClientSet, namespaceName, istioMode)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateNameSpace, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateNameSpace, err)
 	}
 
 	err = crateDeployment(ctx, awsAccountID, awsConfig, k8sClientSet, namespaceName, resourceName, istioMode, isTest)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateDeployment, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateDeployment, err)
 	}
 
 	err = createService(ctx, k8sClientSet, namespaceName, resourceName)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateService, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateService, err)
 	}
 
 	return nil
@@ -78,7 +80,7 @@ func createNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, na
 			LabelSelector: "app=istiod",
 		})
 		if err != nil {
-			return xerrors.Errorf("%w: %w", errFailedToListPods, err)
+			return fmt.Errorf("%w: %w", errFailedToListPods, err)
 		}
 		hyphenedVersions := []string{}
 		for _, item := range podList.Items {
@@ -86,15 +88,15 @@ func createNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, na
 		}
 		latestVersion := getLatestVersion(hyphenedVersions)
 		if err != nil {
-			return xerrors.Errorf("%w: %w", errFailedToGetLatestVersion, err)
+			return fmt.Errorf("%w: %w", errFailedToGetLatestVersion, err)
 		}
 		namespace.ObjectMeta.Labels["istio.io/rev"] = latestVersion
 	}
 
 	_, err := k8sClientSet.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return xerrors.Errorf("%w: %w", errFailedToCreateNameSpace, err)
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("%w: %w", errFailedToCreateNameSpace, err)
 		}
 		log.Println("[WARN] The namespace already exists")
 	} else {
@@ -170,8 +172,8 @@ func crateDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Con
 
 	_, err := k8sClientSet.AppsV1().Deployments(namespaceName).Create(ctx, deployment, metav1.CreateOptions{})
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return xerrors.Errorf("%w: %w", errFailedToCreateDeployment, err)
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("%w: %w", errFailedToCreateDeployment, err)
 		}
 		log.Println("[WARN] The deployment already exists")
 	} else {
@@ -253,8 +255,8 @@ func createService(ctx context.Context, k8sClientSet *kubernetes.Clientset, name
 	}
 	_, err := k8sClientSet.CoreV1().Services(namespaceName).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return xerrors.Errorf("%w: %w", errFailedToCreateService, err)
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("%w: %w", errFailedToCreateService, err)
 		}
 		log.Println("[WARN] The service already exists")
 	} else {
@@ -266,23 +268,23 @@ func createService(ctx context.Context, k8sClientSet *kubernetes.Clientset, name
 func DeleteK8sResources(ctx context.Context, kubeconfig *restclient.Config, namespaceName, resourceName string) error {
 	k8sClientSet, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateClientSet, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateClientSet, err)
 	}
 	log.Println("[INFO] Clientset of k8s set up successfully")
 
 	err = deleteService(ctx, k8sClientSet, namespaceName, resourceName)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToDeleteService, err)
+		return fmt.Errorf("%w: %w", errFailedToDeleteService, err)
 	}
 
 	err = deleteDeployment(ctx, k8sClientSet, namespaceName, resourceName)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToDeleteDeployment, err)
+		return fmt.Errorf("%w: %w", errFailedToDeleteDeployment, err)
 	}
 
 	err = deleteNamespace(ctx, k8sClientSet, namespaceName)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToDeleteNameSpace, err)
+		return fmt.Errorf("%w: %w", errFailedToDeleteNameSpace, err)
 	}
 
 	return nil
@@ -291,8 +293,8 @@ func DeleteK8sResources(ctx context.Context, kubeconfig *restclient.Config, name
 func deleteService(ctx context.Context, k8sClientSet *kubernetes.Clientset, namespaceName, resourceName string) error {
 	err := k8sClientSet.CoreV1().Services(namespaceName).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return xerrors.Errorf("%w: %w", errFailedToDeleteService, err)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("%w: %w", errFailedToDeleteService, err)
 		}
 		log.Println("[WARN] The service is not found")
 	} else {
@@ -304,8 +306,8 @@ func deleteService(ctx context.Context, k8sClientSet *kubernetes.Clientset, name
 func deleteDeployment(ctx context.Context, k8sClientSet *kubernetes.Clientset, namespaceName, resourceName string) error {
 	err := k8sClientSet.AppsV1().Deployments(namespaceName).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return xerrors.Errorf("%w: %w", errFailedToDeleteDeployment, err)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("%w: %w", errFailedToDeleteDeployment, err)
 		}
 		log.Println("[WARN] The Deployment is not found")
 	} else {
@@ -317,8 +319,8 @@ func deleteDeployment(ctx context.Context, k8sClientSet *kubernetes.Clientset, n
 func deleteNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, namespaceName string) error {
 	err := k8sClientSet.CoreV1().Namespaces().Delete(ctx, namespaceName, metav1.DeleteOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return xerrors.Errorf("%w: %w", errFailedToDeleteNameSpace, err)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("%w: %w", errFailedToDeleteNameSpace, err)
 		}
 		log.Println("[WARN] The Namespace is not found")
 	} else {
@@ -333,14 +335,14 @@ func parseVersion(version string) ([]int, error) {
 	// convert "x-y-z" to [x, y, z]
 	parts := strings.Split(version, "-")
 	if len(parts) != versions {
-		return nil, xerrors.Errorf("invalid version format: %s", version)
+		return nil, fmt.Errorf("%w: %s", errInvalidVersionFormat, version)
 	}
 
 	intParts := make([]int, len(parts))
 	for i, part := range parts {
 		num, err := strconv.Atoi(part)
 		if err != nil {
-			return nil, xerrors.Errorf("invalid number in version: %s", part)
+			return nil, fmt.Errorf("%w: %s", errInvalidNumberInVersion, part)
 		}
 		intParts[i] = num
 	}

--- a/app/k8s/k8s.go
+++ b/app/k8s/k8s.go
@@ -38,6 +38,8 @@ var (
 	errFailedToListPods         = errors.New("failed to list pods")
 	errFailedToGetLatestVersion = errors.New("failed to get latest version")
 	errNoValidVersionFound      = errors.New("no valid version found")
+	errInvalidVersionFormat     = errors.New("invalid version format")
+	errInvalidNumberInVersion   = errors.New("invalid number in version")
 )
 
 func CreateK8sResources(ctx context.Context, awsAccountID string, awsConfig aws.Config, kubeconfig *restclient.Config, namespaceName, resourceName string, istioMode, isTest bool) error {
@@ -334,14 +336,14 @@ func parseVersion(version string) ([]int, error) {
 	// convert "x-y-z" to [x, y, z]
 	parts := strings.Split(version, "-")
 	if len(parts) != versions {
-		return nil, fmt.Errorf("invalid version format: %s", version)
+		return nil, fmt.Errorf("%w: %s", errInvalidVersionFormat, version)
 	}
 
 	intParts := make([]int, len(parts))
 	for i, part := range parts {
 		num, err := strconv.Atoi(part)
 		if err != nil {
-			return nil, fmt.Errorf("invalid number in version: %s", part)
+			return nil, fmt.Errorf("%w: %s", errInvalidNumberInVersion, part)
 		}
 		intParts[i] = num
 	}

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"time"
 
-	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -164,24 +163,24 @@ func ValidateParams() error {
 		switch v := value.(type) {
 		case string:
 			if v == "" {
-				return xerrors.Errorf("%w: %s", errEmptyParameter, name)
+				return fmt.Errorf("%w: %s", errEmptyParameter, name)
 			}
 		case int:
 			if v == 0 {
-				return xerrors.Errorf("%w: %s", errEmptyParameter, name)
+				return fmt.Errorf("%w: %s", errEmptyParameter, name)
 			}
 		case time.Duration:
 			if v == 0*time.Millisecond {
-				return xerrors.Errorf("%w: %s", errEmptyParameter, name)
+				return fmt.Errorf("%w: %s", errEmptyParameter, name)
 			}
 		default:
-			return xerrors.Errorf("%w: %s", errUnsupportedParameterType, name)
+			return fmt.Errorf("%w: %s", errUnsupportedParameterType, name)
 		}
 	}
 
 	for _, expr := range NodeAffinityMatchExpressions {
 		if !validNodeSelectorOperators[expr.Operator] {
-			return xerrors.Errorf("%w: %s", errInvalidNodeSelectorOperator, expr.Operator)
+			return fmt.Errorf("%w: %s", errInvalidNodeSelectorOperator, expr.Operator)
 		}
 	}
 

--- a/app/registry/ecr.go
+++ b/app/registry/ecr.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/gold-kou/prism-in-k8s/app/params"
-	"golang.org/x/xerrors"
 )
 
 var (
@@ -30,7 +29,7 @@ func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, re
 	imageTag := params.MicroserviceName + ":v1"
 	cmd := exec.Command("docker", "build", "--platform", "linux/amd64", "-f", "Dockerfile.prism", "-t", imageTag, ".")
 	if err := cmd.Run(); err != nil {
-		return xerrors.Errorf("%s: %v", errFailedToBuildDockerImage, err)
+		return fmt.Errorf("%w: %w", errFailedToBuildDockerImage, err)
 	}
 	log.Println("[INFO] Docker image is built successfully")
 
@@ -56,7 +55,7 @@ func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, re
 	if err != nil {
 		var ecrExistsException *types.RepositoryAlreadyExistsException
 		if !errors.As(err, &ecrExistsException) {
-			return xerrors.Errorf("%w: %w", errFailedToCreateECR, err)
+			return fmt.Errorf("%w: %w", errFailedToCreateECR, err)
 		}
 		log.Println("[WARN] The ECR already exists")
 	} else {
@@ -67,21 +66,21 @@ func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, re
 	ecrImageTag := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:latest", awsAccountID, awsConfig.Region, repositoryName)
 	cmdTag := exec.Command("docker", "tag", imageTag, ecrImageTag)
 	if err := cmdTag.Run(); err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToTagImage, err)
+		return fmt.Errorf("%w: %w", errFailedToTagImage, err)
 	}
 	log.Println("[INFO] Docker image tagged successfully")
 
 	// login to ECR
 	err = loginToECR(ctx, awsConfig, awsAccountID)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToLoginECR, err)
+		return fmt.Errorf("%w: %w", errFailedToLoginECR, err)
 	}
 	log.Println("[INFO] Logged in ECR successfully")
 
 	// push image to ECR
 	cmdPush := exec.Command("docker", "push", ecrImageTag)
 	if err := cmdPush.Run(); err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToPushImage, err)
+		return fmt.Errorf("%w: %w", errFailedToPushImage, err)
 	}
 	log.Println("[INFO] Docker image is pushed to ECR successfully")
 	return nil
@@ -140,7 +139,7 @@ func DeleteECR(ctx context.Context, awsConfig aws.Config, resourceName string) e
 	if err != nil {
 		var ecrNotFoundException *types.RepositoryNotFoundException
 		if !errors.As(err, &ecrNotFoundException) {
-			return xerrors.Errorf("%w: %w", errFailedToDeleteECR, err)
+			return fmt.Errorf("%w: %w", errFailedToDeleteECR, err)
 		}
 		log.Println("[WARN] The ECR is not found")
 	} else {

--- a/app/run.go
+++ b/app/run.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -12,9 +14,14 @@ import (
 	"github.com/gold-kou/prism-in-k8s/app/k8s"
 	"github.com/gold-kou/prism-in-k8s/app/params"
 	"github.com/gold-kou/prism-in-k8s/app/registry"
-	"golang.org/x/xerrors"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	errFailedToLoadAWSConfig     = errors.New("failed to load AWS config")
+	errFailedToGetCallerIdentity = errors.New("failed to get caller identity")
+	errFailedToBuildKubeConfig   = errors.New("failed to build Kubeconfig")
 )
 
 var (
@@ -45,14 +52,14 @@ func init() {
 		// AWS config
 		awsConfig, err = config.LoadDefaultConfig(context.Background())
 		if err != nil {
-			panic(xerrors.Errorf("failed load AWS config: %v", err))
+			panic(fmt.Errorf("%w: %w", errFailedToLoadAWSConfig, err))
 		}
 
 		// get AWS account ID
 		stsClient := sts.NewFromConfig(awsConfig)
 		result, err := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
 		if err != nil {
-			panic(xerrors.Errorf("failed to get caller identity: %v", err))
+			panic(fmt.Errorf("%w: %w", errFailedToGetCallerIdentity, err))
 		}
 		awsAccountID = *result.Account
 	}
@@ -61,7 +68,7 @@ func init() {
 	kubeconfigPath := clientcmd.NewDefaultPathOptions().GetDefaultFilename()
 	kubeConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
-		panic(xerrors.Errorf("failed to build Kubeconfig: %v", err))
+		panic(fmt.Errorf("%w: %w", errFailedToBuildKubeConfig, err))
 	}
 
 	// resource name

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.1
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
-	github.com/pingcap/errors v0.11.4
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 	gopkg.in/yaml.v2 v2.4.0
 	istio.io/api v1.22.3-0.20240703105953-437a88321a16
 	istio.io/client-go v1.22.3

--- a/go.sum
+++ b/go.sum
@@ -91,10 +91,6 @@ github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY
 github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
 github.com/onsi/gomega v1.31.0 h1:54UJxxj6cPInHS3a35wm6BK/F9nHYueZ1NVujHDrnXE=
 github.com/onsi/gomega v1.31.0/go.mod h1:DW9aCi7U6Yi40wNVAvT6kzFnEVEI5n3DloYBiKiT6zk=
-github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
-github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
@@ -153,8 +149,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto/googleapis/api v0.0.0-20241104194629-dd2ea8efbc28 h1:M0KvPgPmDZHPlbRbaNU1APr28TvwvvdUPlSv7PUvy8g=


### PR DESCRIPTION
## Summary
- Replace mixed error libraries (`xerrors`, `pingcap/errors`) with standard `fmt.Errorf` using `%w`
- Use `k8s.io/apimachinery/pkg/api/errors` directly for `IsAlreadyExists`/`IsNotFound`
- Add proper sentinel errors where needed for linter compliance

## Test plan
- [ ] `go build ./...` passes
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)