### PR TITLE
Remove global state and init() functions

### DIFF
--- a/app/istio/istio.go
+++ b/app/istio/istio.go
@@ -2,14 +2,15 @@ package istio
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 
 	"github.com/golang/protobuf/ptypes/duration"
-	"github.com/pingcap/errors"
-	"golang.org/x/xerrors"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"istio.io/client-go/pkg/clientset/versioned"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 )
@@ -29,7 +30,7 @@ func CreateIstioResources(ctx context.Context, kubeconfig *restclient.Config, na
 	// Istio clientset
 	istioClientSet, err := versioned.NewForConfig(kubeconfig)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateIstioClient, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateIstioClient, err)
 	}
 
 	// VirtualService
@@ -91,8 +92,8 @@ func CreateIstioResources(ctx context.Context, kubeconfig *restclient.Config, na
 	}
 	_, err = istioClientSet.NetworkingV1alpha3().VirtualServices(namespaceName).Create(ctx, virtualService, metav1.CreateOptions{})
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return xerrors.Errorf("%w: %w", errFailedToCreateVirtualService, err)
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("%w: %w", errFailedToCreateVirtualService, err)
 		}
 		log.Println("[WARN] The VirtualService already exists")
 	} else {
@@ -105,14 +106,14 @@ func DeleteIstioResources(ctx context.Context, kubeconfig *restclient.Config, na
 	// Istio clientset
 	istioClientSet, err := versioned.NewForConfig(kubeconfig)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateIstioClient, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateIstioClient, err)
 	}
 	log.Println("[INFO] Clientset of istio set up successfully")
 
 	err = istioClientSet.NetworkingV1alpha3().VirtualServices(namespaceName).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return xerrors.Errorf("%w: %w", errFailedToDeleteVirtualService, err)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("%w: %w", errFailedToDeleteVirtualService, err)
 		}
 		log.Println("[WARN] The VirtualService is not found")
 	} else {

--- a/app/k8s/k8s.go
+++ b/app/k8s/k8s.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -10,10 +11,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gold-kou/prism-in-k8s/app/params"
 	"github.com/gold-kou/prism-in-k8s/app/util"
-	"github.com/pingcap/errors"
-	"golang.org/x/xerrors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -37,27 +37,29 @@ var (
 	errFailedToDeleteService    = errors.New("failed to delete service")
 	errFailedToListPods         = errors.New("failed to list pods")
 	errFailedToGetLatestVersion = errors.New("failed to get latest version")
+	errInvalidVersionFormat     = errors.New("invalid version format")
+	errInvalidNumberInVersion   = errors.New("invalid number in version")
 )
 
-func CreateK8sResources(ctx context.Context, awsAccountID string, awsConfig aws.Config, kubeconfig *restclient.Config, namespaceName, resourceName string, istioMode, isTest bool) error {
+func CreateK8sResources(ctx context.Context, awsAccountID string, awsConfig aws.Config, kubeconfig *restclient.Config, namespaceName, resourceName string, cfg *params.Config, isTest bool) error {
 	k8sClientSet, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateClientSet, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateClientSet, err)
 	}
 
-	err = createNamespace(ctx, k8sClientSet, namespaceName, istioMode)
+	err = createNamespace(ctx, k8sClientSet, namespaceName, cfg.IstioMode)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateNameSpace, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateNameSpace, err)
 	}
 
-	err = crateDeployment(ctx, awsAccountID, awsConfig, k8sClientSet, namespaceName, resourceName, istioMode, isTest)
+	err = crateDeployment(ctx, awsAccountID, awsConfig, k8sClientSet, namespaceName, resourceName, cfg, isTest)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateDeployment, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateDeployment, err)
 	}
 
 	err = createService(ctx, k8sClientSet, namespaceName, resourceName)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateService, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateService, err)
 	}
 
 	return nil
@@ -78,23 +80,23 @@ func createNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, na
 			LabelSelector: "app=istiod",
 		})
 		if err != nil {
-			return xerrors.Errorf("%w: %w", errFailedToListPods, err)
+			return fmt.Errorf("%w: %w", errFailedToListPods, err)
 		}
 		hyphenedVersions := []string{}
 		for _, item := range podList.Items {
 			hyphenedVersions = append(hyphenedVersions, item.ObjectMeta.Labels["istio.io/rev"])
 		}
-		latestVersion := getLatestVersion(hyphenedVersions)
+		latestVersion, err := getLatestVersion(hyphenedVersions)
 		if err != nil {
-			return xerrors.Errorf("%w: %w", errFailedToGetLatestVersion, err)
+			return fmt.Errorf("%w: %w", errFailedToGetLatestVersion, err)
 		}
 		namespace.ObjectMeta.Labels["istio.io/rev"] = latestVersion
 	}
 
 	_, err := k8sClientSet.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return xerrors.Errorf("%w: %w", errFailedToCreateNameSpace, err)
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("%w: %w", errFailedToCreateNameSpace, err)
 		}
 		log.Println("[WARN] The namespace already exists")
 	} else {
@@ -103,7 +105,7 @@ func createNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, na
 	return nil
 }
 
-func crateDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Config, k8sClientSet *kubernetes.Clientset, namespaceName, resourceName string, istioMode, isTest bool) error {
+func crateDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Config, k8sClientSet *kubernetes.Clientset, namespaceName, resourceName string, cfg *params.Config, isTest bool) error {
 	// Prism image
 	prismImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", awsAccountID, awsConfig.Region, resourceName)
 	if isTest {
@@ -136,42 +138,42 @@ func crateDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Con
 							Image: prismImage,
 							Ports: []corev1.ContainerPort{
 								{
-									ContainerPort: int32(params.PrismPort),
+									ContainerPort: int32(cfg.PrismPort),
 								},
 							},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse(params.PrismCPU),
-									corev1.ResourceMemory: resource.MustParse(params.PrismMemory),
+									corev1.ResourceCPU:    resource.MustParse(cfg.PrismCPU),
+									corev1.ResourceMemory: resource.MustParse(cfg.PrismMemory),
 								},
 							},
 						},
 					},
-					PriorityClassName: params.PriorityClassName,
+					PriorityClassName: cfg.PriorityClassName,
 				},
 			},
 		},
 	}
 
-	deployment.Spec.Template.Spec.Affinity = buildAffinity(resourceName)
+	deployment.Spec.Template.Spec.Affinity = buildAffinity(resourceName, cfg)
 
 	if isTest {
 		// to get image from local
 		deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullNever
 	}
 
-	if istioMode {
+	if cfg.IstioMode {
 		deployment.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"] = "true"
-		deployment.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/proxyCPULimit"] = params.IstioProxyCPU
-		deployment.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/proxyMemoryLimit"] = params.IstioProxyMemory
+		deployment.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/proxyCPULimit"] = cfg.IstioProxyCPU
+		deployment.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/proxyMemoryLimit"] = cfg.IstioProxyMemory
 		deployment.Spec.Template.ObjectMeta.Annotations["traffic.sidecar.istio.io/includeOutboundIPRanges"] = "*"
 		deployment.Spec.Template.ObjectMeta.Annotations["proxy.istio.io/config"] = `{ "terminationDrainDuration": "30s" }`
 	}
 
 	_, err := k8sClientSet.AppsV1().Deployments(namespaceName).Create(ctx, deployment, metav1.CreateOptions{})
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return xerrors.Errorf("%w: %w", errFailedToCreateDeployment, err)
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("%w: %w", errFailedToCreateDeployment, err)
 		}
 		log.Println("[WARN] The deployment already exists")
 	} else {
@@ -180,9 +182,9 @@ func crateDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Con
 	return nil
 }
 
-func buildAffinity(resourceName string) *corev1.Affinity {
-	hasNodeAffinity := len(params.NodeAffinityMatchExpressions) > 0
-	hasPodAntiAffinity := params.PodAntiAffinityTopologyKey != ""
+func buildAffinity(resourceName string, cfg *params.Config) *corev1.Affinity {
+	hasNodeAffinity := len(cfg.NodeAffinityMatchExpressions) > 0
+	hasPodAntiAffinity := cfg.PodAntiAffinityTopologyKey != ""
 
 	if !hasNodeAffinity && !hasPodAntiAffinity {
 		return nil
@@ -191,8 +193,8 @@ func buildAffinity(resourceName string) *corev1.Affinity {
 	affinity := &corev1.Affinity{}
 
 	if hasNodeAffinity {
-		matchExpressions := make([]corev1.NodeSelectorRequirement, 0, len(params.NodeAffinityMatchExpressions))
-		for _, expr := range params.NodeAffinityMatchExpressions {
+		matchExpressions := make([]corev1.NodeSelectorRequirement, 0, len(cfg.NodeAffinityMatchExpressions))
+		for _, expr := range cfg.NodeAffinityMatchExpressions {
 			matchExpressions = append(matchExpressions, corev1.NodeSelectorRequirement{
 				Key:      expr.Key,
 				Operator: corev1.NodeSelectorOperator(expr.Operator),
@@ -223,7 +225,7 @@ func buildAffinity(resourceName string) *corev1.Affinity {
 							},
 						},
 					},
-					TopologyKey: params.PodAntiAffinityTopologyKey,
+					TopologyKey: cfg.PodAntiAffinityTopologyKey,
 				},
 			},
 		}
@@ -253,8 +255,8 @@ func createService(ctx context.Context, k8sClientSet *kubernetes.Clientset, name
 	}
 	_, err := k8sClientSet.CoreV1().Services(namespaceName).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return xerrors.Errorf("%w: %w", errFailedToCreateService, err)
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("%w: %w", errFailedToCreateService, err)
 		}
 		log.Println("[WARN] The service already exists")
 	} else {
@@ -266,23 +268,23 @@ func createService(ctx context.Context, k8sClientSet *kubernetes.Clientset, name
 func DeleteK8sResources(ctx context.Context, kubeconfig *restclient.Config, namespaceName, resourceName string) error {
 	k8sClientSet, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToCreateClientSet, err)
+		return fmt.Errorf("%w: %w", errFailedToCreateClientSet, err)
 	}
 	log.Println("[INFO] Clientset of k8s set up successfully")
 
 	err = deleteService(ctx, k8sClientSet, namespaceName, resourceName)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToDeleteService, err)
+		return fmt.Errorf("%w: %w", errFailedToDeleteService, err)
 	}
 
 	err = deleteDeployment(ctx, k8sClientSet, namespaceName, resourceName)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToDeleteDeployment, err)
+		return fmt.Errorf("%w: %w", errFailedToDeleteDeployment, err)
 	}
 
 	err = deleteNamespace(ctx, k8sClientSet, namespaceName)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToDeleteNameSpace, err)
+		return fmt.Errorf("%w: %w", errFailedToDeleteNameSpace, err)
 	}
 
 	return nil
@@ -291,8 +293,8 @@ func DeleteK8sResources(ctx context.Context, kubeconfig *restclient.Config, name
 func deleteService(ctx context.Context, k8sClientSet *kubernetes.Clientset, namespaceName, resourceName string) error {
 	err := k8sClientSet.CoreV1().Services(namespaceName).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return xerrors.Errorf("%w: %w", errFailedToDeleteService, err)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("%w: %w", errFailedToDeleteService, err)
 		}
 		log.Println("[WARN] The service is not found")
 	} else {
@@ -304,8 +306,8 @@ func deleteService(ctx context.Context, k8sClientSet *kubernetes.Clientset, name
 func deleteDeployment(ctx context.Context, k8sClientSet *kubernetes.Clientset, namespaceName, resourceName string) error {
 	err := k8sClientSet.AppsV1().Deployments(namespaceName).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return xerrors.Errorf("%w: %w", errFailedToDeleteDeployment, err)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("%w: %w", errFailedToDeleteDeployment, err)
 		}
 		log.Println("[WARN] The Deployment is not found")
 	} else {
@@ -317,8 +319,8 @@ func deleteDeployment(ctx context.Context, k8sClientSet *kubernetes.Clientset, n
 func deleteNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, namespaceName string) error {
 	err := k8sClientSet.CoreV1().Namespaces().Delete(ctx, namespaceName, metav1.DeleteOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return xerrors.Errorf("%w: %w", errFailedToDeleteNameSpace, err)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("%w: %w", errFailedToDeleteNameSpace, err)
 		}
 		log.Println("[WARN] The Namespace is not found")
 	} else {
@@ -333,14 +335,14 @@ func parseVersion(version string) ([]int, error) {
 	// convert "x-y-z" to [x, y, z]
 	parts := strings.Split(version, "-")
 	if len(parts) != versions {
-		return nil, xerrors.Errorf("invalid version format: %s", version)
+		return nil, fmt.Errorf("%w: %s", errInvalidVersionFormat, version)
 	}
 
 	intParts := make([]int, len(parts))
 	for i, part := range parts {
 		num, err := strconv.Atoi(part)
 		if err != nil {
-			return nil, xerrors.Errorf("invalid number in version: %s", part)
+			return nil, fmt.Errorf("%w: %s", errInvalidNumberInVersion, part)
 		}
 		intParts[i] = num
 	}
@@ -361,26 +363,30 @@ func compareVersions(v1, v2 []int) int {
 	return 0
 }
 
-func getLatestVersion(versions []string) string {
+func getLatestVersion(versions []string) (string, error) {
 	if len(versions) == 0 {
-		return ""
+		return "", nil
 	}
 
-	// init max with the zero index element
-	maxVersion := versions[0]
-	// ignore err
-	maxVersionParts, _ := parseVersion(maxVersion)
+	maxVersion := ""
+	var maxVersionParts []int
 
-	// compare all versions
-	for _, version := range versions[1:] {
-		// ignore err
-		versionParts, _ := parseVersion(version)
+	for _, version := range versions {
+		versionParts, err := parseVersion(version)
+		if err != nil {
+			log.Printf("[WARN] Skipping invalid version %q: %v", version, err)
+			continue
+		}
 
-		if compareVersions(versionParts, maxVersionParts) > 0 {
+		if maxVersionParts == nil || compareVersions(versionParts, maxVersionParts) > 0 {
 			maxVersion = version
 			maxVersionParts = versionParts
 		}
 	}
 
-	return maxVersion
+	if maxVersion == "" {
+		return "", fmt.Errorf("%w: %v", errFailedToGetLatestVersion, versions)
+	}
+
+	return maxVersion, nil
 }

--- a/app/k8s/k8s_test.go
+++ b/app/k8s/k8s_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/gold-kou/prism-in-k8s/app/k8s"
+	"github.com/gold-kou/prism-in-k8s/app/params"
 	"github.com/gold-kou/prism-in-k8s/app/testutil"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -27,8 +28,17 @@ func TestCreateK8sResources(t *testing.T) {
 	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	require.NoError(t, err)
 
+	cfg := &params.Config{
+		PrismPort:        params.DefaultPrismPort,
+		PrismCPU:         params.DefaultPrismCPU,
+		PrismMemory:      params.DefaultPrismMemory,
+		IstioMode:        true,
+		IstioProxyCPU:    params.DefaultIstioProxyCPU,
+		IstioProxyMemory: params.DefaultIstioProxyMemory,
+	}
+
 	// test target
-	err = k8s.CreateK8sResources(ctx, dummyAWSAccountID, awsConfig, kubeconfig, testNamespaceName, testResourceName, true, true)
+	err = k8s.CreateK8sResources(ctx, dummyAWSAccountID, awsConfig, kubeconfig, testNamespaceName, testResourceName, cfg, true)
 	require.NoError(t, err)
 
 	// verify

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -3,30 +3,27 @@ package params
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"time"
 
-	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v2"
 )
 
 const (
-	defaultTimeout          = 10 * time.Minute
-	defaultPrismPort        = 80
-	defaultPrismCPU         = "500m"
-	defaultPrismMemory      = "512Mi"
-	defaultIstioMode        = true
-	defaultIstioProxyCPU    = "500m"
-	defaultIstioProxyMemory = "512Mi"
+	DefaultTimeout          = 10 * time.Minute
+	DefaultPrismPort        = 80
+	DefaultPrismCPU         = "500m"
+	DefaultPrismMemory      = "512Mi"
+	DefaultIstioProxyCPU    = "500m"
+	DefaultIstioProxyMemory = "512Mi"
 )
 
 var (
-	errEmptyParameter                = errors.New("empty parameter found")
-	errUnsupportedParameterType      = errors.New("unsupported parameter type")
-	errFailedToOpenConfigFile        = errors.New("failed to open config file")
-	errFailedToDecodeConfigFile      = errors.New("failed to decode config file")
-	errInvalidNodeSelectorOperator   = errors.New("invalid node selector operator")
+	errEmptyParameter              = errors.New("empty parameter found")
+	errUnsupportedParameterType    = errors.New("unsupported parameter type")
+	errFailedToOpenConfigFile      = errors.New("failed to open config file")
+	errFailedToDecodeConfigFile    = errors.New("failed to decode config file")
+	errInvalidNodeSelectorOperator = errors.New("invalid node selector operator")
 )
 
 var validNodeSelectorOperators = map[string]bool{
@@ -34,40 +31,23 @@ var validNodeSelectorOperators = map[string]bool{
 	"DoesNotExist": true, "Gt": true, "Lt": true,
 }
 
-var (
-	// required parameters
-	MicroserviceName      string
-	MicroserviceNamespace string
-	PrismMockSuffix       string
-	// optional parameters
-	Timeout           time.Duration
-	PrismPort         int
-	PrismCPU          string
-	PrismMemory       string
-	IstioMode         bool
-	IstioProxyCPU     string
-	IstioProxyMemory  string
-	PriorityClassName            string
-	NodeAffinityMatchExpressions []NodeAffinityMatchExpression
-	PodAntiAffinityTopologyKey   string
-	EcrTags                      []ECRTag
-)
-
 type Config struct {
-	MicroserviceName      string        `yaml:"microserviceName"`
-	MicroserviceNamespace string        `yaml:"microserviceNamespace"`
-	PrismMockSuffix       string        `yaml:"prismMockSuffix"`
-	Timeout               time.Duration `yaml:"timeout"`
-	PrismPort             int           `yaml:"prismPort"`
-	PrismCPU              string        `yaml:"prismCpu"`
-	PrismMemory           string        `yaml:"prismMemory"`
-	IstioMode             bool          `yaml:"istioMode"`
-	IstioProxyCPU         string        `yaml:"istioProxyCpu"`
-	IstioProxyMemory      string        `yaml:"istioProxyMemory"`
-	PriorityClassName            string                       `yaml:"priorityClassName"`
+	// required parameters
+	MicroserviceName      string `yaml:"microserviceName"`
+	MicroserviceNamespace string `yaml:"microserviceNamespace"`
+	PrismMockSuffix       string `yaml:"prismMockSuffix"`
+	// optional parameters
+	Timeout                      time.Duration                 `yaml:"timeout"`
+	PrismPort                    int                           `yaml:"prismPort"`
+	PrismCPU                     string                        `yaml:"prismCpu"`
+	PrismMemory                  string                        `yaml:"prismMemory"`
+	IstioMode                    bool                          `yaml:"istioMode"`
+	IstioProxyCPU                string                        `yaml:"istioProxyCpu"`
+	IstioProxyMemory             string                        `yaml:"istioProxyMemory"`
+	PriorityClassName            string                        `yaml:"priorityClassName"`
 	NodeAffinityMatchExpressions []NodeAffinityMatchExpression `yaml:"nodeAffinity"`
-	PodAntiAffinityTopologyKey   string                       `yaml:"podAntiAffinityTopologyKey"`
-	EcrTags                      []ECRTag                     `yaml:"ecrTags"`
+	PodAntiAffinityTopologyKey   string                        `yaml:"podAntiAffinityTopologyKey"`
+	EcrTags                      []ECRTag                      `yaml:"ecrTags"`
 }
 
 type NodeAffinityMatchExpression struct {
@@ -79,56 +59,6 @@ type NodeAffinityMatchExpression struct {
 type ECRTag struct {
 	Key   string `yaml:"key"`
 	Value string `yaml:"value"`
-}
-
-func init() {
-	path := os.Getenv("PARAMS_CONFIG_PATH")
-	if path == "" {
-		log.Fatal("PARAMS_CONFIG_PATH is not set")
-	}
-	config, err := LoadConfig(path)
-	if err != nil {
-		log.Fatalf("Error loading config: %v", err)
-	}
-
-	// required parameters
-	MicroserviceName = config.MicroserviceName
-	MicroserviceNamespace = config.MicroserviceNamespace
-	PrismMockSuffix = config.PrismMockSuffix
-
-	// optional parameters
-	Timeout = defaultTimeout
-	if config.Timeout != 0 {
-		Timeout = config.Timeout
-	}
-	PrismPort = defaultPrismPort
-	if config.PrismPort != 0 {
-		PrismPort = config.PrismPort
-	}
-	PrismCPU = defaultPrismCPU
-	if config.PrismCPU != "" {
-		PrismCPU = config.PrismCPU
-	}
-	PrismMemory = defaultPrismMemory
-	if config.PrismMemory != "" {
-		PrismMemory = config.PrismMemory
-	}
-	IstioMode = false
-	if config.IstioMode {
-		IstioMode = config.IstioMode
-	}
-	IstioProxyCPU = defaultIstioProxyCPU
-	if config.IstioProxyCPU != "" {
-		IstioProxyCPU = config.IstioProxyCPU
-	}
-	IstioProxyMemory = defaultIstioProxyMemory
-	if config.IstioProxyMemory != "" {
-		IstioProxyMemory = config.IstioProxyMemory
-	}
-	PriorityClassName = config.PriorityClassName
-	NodeAffinityMatchExpressions = config.NodeAffinityMatchExpressions
-	PodAntiAffinityTopologyKey = config.PodAntiAffinityTopologyKey
-	EcrTags = config.EcrTags
 }
 
 func LoadConfig(filename string) (*Config, error) {
@@ -144,44 +74,67 @@ func LoadConfig(filename string) (*Config, error) {
 		return nil, fmt.Errorf("%w: %w", errFailedToDecodeConfigFile, err)
 	}
 
+	config.ApplyDefaults()
+
 	return &config, nil
 }
 
-func ValidateParams() error {
+func (c *Config) ApplyDefaults() {
+	if c.Timeout == 0 {
+		c.Timeout = DefaultTimeout
+	}
+	if c.PrismPort == 0 {
+		c.PrismPort = DefaultPrismPort
+	}
+	if c.PrismCPU == "" {
+		c.PrismCPU = DefaultPrismCPU
+	}
+	if c.PrismMemory == "" {
+		c.PrismMemory = DefaultPrismMemory
+	}
+	if c.IstioProxyCPU == "" {
+		c.IstioProxyCPU = DefaultIstioProxyCPU
+	}
+	if c.IstioProxyMemory == "" {
+		c.IstioProxyMemory = DefaultIstioProxyMemory
+	}
+}
+
+func (c *Config) Validate() error {
 	params := map[string]interface{}{
-		"microserviceName":      MicroserviceName,
-		"microserviceNamespace": MicroserviceNamespace,
-		"prismMockSuffix":       PrismMockSuffix,
-		"timeout":               Timeout,
-		"prismPort":             PrismPort,
-		"prismCPU":              PrismCPU,
-		"prismMemory":           PrismMemory,
-		"istioProxyCPU":         IstioProxyCPU,
-		"istioProxyMemory":      IstioProxyMemory,
+		"microserviceName":      c.MicroserviceName,
+		"microserviceNamespace": c.MicroserviceNamespace,
+		"prismMockSuffix":       c.PrismMockSuffix,
+		"timeout":               c.Timeout,
+		"prismPort":             c.PrismPort,
+		"prismCPU":              c.PrismCPU,
+		"prismMemory":           c.PrismMemory,
+		"istioProxyCPU":         c.IstioProxyCPU,
+		"istioProxyMemory":      c.IstioProxyMemory,
 	}
 
 	for name, value := range params {
 		switch v := value.(type) {
 		case string:
 			if v == "" {
-				return xerrors.Errorf("%w: %s", errEmptyParameter, name)
+				return fmt.Errorf("%w: %s", errEmptyParameter, name)
 			}
 		case int:
 			if v == 0 {
-				return xerrors.Errorf("%w: %s", errEmptyParameter, name)
+				return fmt.Errorf("%w: %s", errEmptyParameter, name)
 			}
 		case time.Duration:
 			if v == 0*time.Millisecond {
-				return xerrors.Errorf("%w: %s", errEmptyParameter, name)
+				return fmt.Errorf("%w: %s", errEmptyParameter, name)
 			}
 		default:
-			return xerrors.Errorf("%w: %s", errUnsupportedParameterType, name)
+			return fmt.Errorf("%w: %s", errUnsupportedParameterType, name)
 		}
 	}
 
-	for _, expr := range NodeAffinityMatchExpressions {
+	for _, expr := range c.NodeAffinityMatchExpressions {
 		if !validNodeSelectorOperators[expr.Operator] {
-			return xerrors.Errorf("%w: %s", errInvalidNodeSelectorOperator, expr.Operator)
+			return fmt.Errorf("%w: %s", errInvalidNodeSelectorOperator, expr.Operator)
 		}
 	}
 

--- a/app/registry/ecr.go
+++ b/app/registry/ecr.go
@@ -13,30 +13,29 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/gold-kou/prism-in-k8s/app/params"
-	"golang.org/x/xerrors"
 )
 
 var (
 	errFailedToBuildDockerImage = errors.New("failed to build docker image")
-	errFailedToCreateECR        = errors.New("failed to create ECR repository")
-	errFailedToTagImage         = errors.New("failed to tag image")
-	errFailedToLoginECR         = errors.New("failed to log in ECR")
-	errFailedToPushImage        = errors.New("failed to push image to ECR")
-	errFailedToDeleteECR        = errors.New("failed to delete ECR repository")
+	errFailedToCreateECR       = errors.New("failed to create ECR repository")
+	errFailedToTagImage        = errors.New("failed to tag image")
+	errFailedToLoginECR        = errors.New("failed to log in ECR")
+	errFailedToPushImage       = errors.New("failed to push image to ECR")
+	errFailedToDeleteECR       = errors.New("failed to delete ECR repository")
 )
 
-func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, resourceName string) error {
+func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, resourceName string, cfg *params.Config) error {
 	// build Docker image
-	imageTag := params.MicroserviceName + ":v1"
+	imageTag := cfg.MicroserviceName + ":v1"
 	cmd := exec.Command("docker", "build", "--platform", "linux/amd64", "-f", "Dockerfile.prism", "-t", imageTag, ".")
 	if err := cmd.Run(); err != nil {
-		return xerrors.Errorf("%s: %v", errFailedToBuildDockerImage, err)
+		return fmt.Errorf("%w: %w", errFailedToBuildDockerImage, err)
 	}
 	log.Println("[INFO] Docker image is built successfully")
 
 	// ECR tags
 	tags := []types.Tag{}
-	for _, ecrTag := range params.EcrTags {
+	for _, ecrTag := range cfg.EcrTags {
 		if ecrTag.Key != "" || ecrTag.Value != "" {
 			tags = append(tags, types.Tag{
 				Key:   aws.String(ecrTag.Key),
@@ -56,7 +55,7 @@ func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, re
 	if err != nil {
 		var ecrExistsException *types.RepositoryAlreadyExistsException
 		if !errors.As(err, &ecrExistsException) {
-			return xerrors.Errorf("%w: %w", errFailedToCreateECR, err)
+			return fmt.Errorf("%w: %w", errFailedToCreateECR, err)
 		}
 		log.Println("[WARN] The ECR already exists")
 	} else {
@@ -67,21 +66,21 @@ func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, re
 	ecrImageTag := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:latest", awsAccountID, awsConfig.Region, repositoryName)
 	cmdTag := exec.Command("docker", "tag", imageTag, ecrImageTag)
 	if err := cmdTag.Run(); err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToTagImage, err)
+		return fmt.Errorf("%w: %w", errFailedToTagImage, err)
 	}
 	log.Println("[INFO] Docker image tagged successfully")
 
 	// login to ECR
 	err = loginToECR(ctx, awsConfig, awsAccountID)
 	if err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToLoginECR, err)
+		return fmt.Errorf("%w: %w", errFailedToLoginECR, err)
 	}
 	log.Println("[INFO] Logged in ECR successfully")
 
 	// push image to ECR
 	cmdPush := exec.Command("docker", "push", ecrImageTag)
 	if err := cmdPush.Run(); err != nil {
-		return xerrors.Errorf("%w: %w", errFailedToPushImage, err)
+		return fmt.Errorf("%w: %w", errFailedToPushImage, err)
 	}
 	log.Println("[INFO] Docker image is pushed to ECR successfully")
 	return nil
@@ -140,7 +139,7 @@ func DeleteECR(ctx context.Context, awsConfig aws.Config, resourceName string) e
 	if err != nil {
 		var ecrNotFoundException *types.RepositoryNotFoundException
 		if !errors.As(err, &ecrNotFoundException) {
-			return xerrors.Errorf("%w: %w", errFailedToDeleteECR, err)
+			return fmt.Errorf("%w: %w", errFailedToDeleteECR, err)
 		}
 		log.Println("[WARN] The ECR is not found")
 	} else {

--- a/app/run.go
+++ b/app/run.go
@@ -2,115 +2,138 @@ package app
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gold-kou/prism-in-k8s/app/istio"
 	"github.com/gold-kou/prism-in-k8s/app/k8s"
 	"github.com/gold-kou/prism-in-k8s/app/params"
 	"github.com/gold-kou/prism-in-k8s/app/registry"
-	"golang.org/x/xerrors"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
-	isCreate      bool
-	isDelete      bool
-	isTest        bool
+	errFailedToLoadAWSConfig     = errors.New("failed to load AWS config")
+	errFailedToGetCallerIdentity = errors.New("failed to get caller identity")
+	errFailedToBuildKubeConfig   = errors.New("failed to build Kubeconfig")
+	errParamsConfigPathNotSet    = errors.New("PARAMS_CONFIG_PATH is not set")
+)
+
+type App struct {
+	config        *params.Config
 	awsConfig     aws.Config
 	awsAccountID  string
 	kubeConfig    *restclient.Config
 	resourceName  string
 	namespaceName string
-)
+	isCreate      bool
+	isDelete      bool
+	isTest        bool
+}
 
-func init() {
-	// command args
-	flag.BoolVar(&isCreate, "create", false, "set to true if running in create mode")
-	flag.BoolVar(&isDelete, "delete", false, "set to true if running in delete mode")
-	flag.BoolVar(&isTest, "test", false, "set to true if running in test mode")
+func NewApp() (*App, error) {
+	application := &App{}
+
+	flag.BoolVar(&application.isCreate, "create", false, "set to true if running in create mode")
+	flag.BoolVar(&application.isDelete, "delete", false, "set to true if running in delete mode")
+	flag.BoolVar(&application.isTest, "test", false, "set to true if running in test mode")
 	flag.Parse()
 
-	// validation parameters
-	err := params.ValidateParams()
-	if err != nil {
-		panic(err)
+	// load and validate config
+	configPath := os.Getenv("PARAMS_CONFIG_PATH")
+	if configPath == "" {
+		return nil, errParamsConfigPathNotSet
 	}
 
-	if !isTest {
+	cfg, err := params.LoadConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+	application.config = cfg
+
+	if !application.isTest {
 		// AWS config
-		awsConfig, err = config.LoadDefaultConfig(context.Background())
+		application.awsConfig, err = awsconfig.LoadDefaultConfig(context.Background())
 		if err != nil {
-			panic(xerrors.Errorf("failed load AWS config: %v", err))
+			return nil, fmt.Errorf("%w: %w", errFailedToLoadAWSConfig, err)
 		}
 
 		// get AWS account ID
-		stsClient := sts.NewFromConfig(awsConfig)
+		stsClient := sts.NewFromConfig(application.awsConfig)
 		result, err := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
 		if err != nil {
-			panic(xerrors.Errorf("failed to get caller identity: %v", err))
+			return nil, fmt.Errorf("%w: %w", errFailedToGetCallerIdentity, err)
 		}
-		awsAccountID = *result.Account
+		application.awsAccountID = *result.Account
 	}
 
 	// kube config
 	kubeconfigPath := clientcmd.NewDefaultPathOptions().GetDefaultFilename()
-	kubeConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	application.kubeConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
-		panic(xerrors.Errorf("failed to build Kubeconfig: %v", err))
+		return nil, fmt.Errorf("%w: %w", errFailedToBuildKubeConfig, err)
 	}
 
 	// resource name
-	resourceName = "test-microservice"
-	namespaceName = "test-namespace"
-	if params.MicroserviceName != "" && params.MicroserviceNamespace != "" {
-		resourceName = params.MicroserviceName + params.PrismMockSuffix
-		namespaceName = params.MicroserviceNamespace + params.PrismMockSuffix
+	application.resourceName = "test-microservice"
+	application.namespaceName = "test-namespace"
+	if cfg.MicroserviceName != "" && cfg.MicroserviceNamespace != "" {
+		application.resourceName = cfg.MicroserviceName + cfg.PrismMockSuffix
+		application.namespaceName = cfg.MicroserviceNamespace + cfg.PrismMockSuffix
 	}
+
+	return application, nil
 }
 
-func Run() {
-	ctx, cancel := context.WithTimeout(context.Background(), params.Timeout)
+func (a *App) Run() {
+	ctx, cancel := context.WithTimeout(context.Background(), a.config.Timeout)
 	defer cancel()
 
-	if isCreate {
-		if !isTest {
-			err := registry.BuildAndPushECR(ctx, awsConfig, awsAccountID, resourceName)
+	if a.isCreate {
+		if !a.isTest {
+			err := registry.BuildAndPushECR(ctx, a.awsConfig, a.awsAccountID, a.resourceName, a.config)
 			if err != nil {
 				panic(err)
 			}
 		}
 
-		err := k8s.CreateK8sResources(ctx, awsAccountID, awsConfig, kubeConfig, namespaceName, resourceName, params.IstioMode, isTest)
+		err := k8s.CreateK8sResources(ctx, a.awsAccountID, a.awsConfig, a.kubeConfig, a.namespaceName, a.resourceName, a.config, a.isTest)
 		if err != nil {
 			panic(err)
 		}
 
-		if params.IstioMode {
-			err = istio.CreateIstioResources(ctx, kubeConfig, namespaceName, resourceName)
+		if a.config.IstioMode {
+			err = istio.CreateIstioResources(ctx, a.kubeConfig, a.namespaceName, a.resourceName)
 			if err != nil {
 				panic(err)
 			}
 		}
 		log.Println("[INFO] All resources for prism mock are created successfully")
-	} else if isDelete {
-		if params.IstioMode {
-			err := istio.DeleteIstioResources(ctx, kubeConfig, namespaceName, resourceName)
+	} else if a.isDelete {
+		if a.config.IstioMode {
+			err := istio.DeleteIstioResources(ctx, a.kubeConfig, a.namespaceName, a.resourceName)
 			if err != nil {
 				panic(err)
 			}
 		}
 
-		err := k8s.DeleteK8sResources(ctx, kubeConfig, namespaceName, resourceName)
+		err := k8s.DeleteK8sResources(ctx, a.kubeConfig, a.namespaceName, a.resourceName)
 		if err != nil {
 			panic(err)
 		}
 
-		err = registry.DeleteECR(ctx, awsConfig, resourceName)
+		err = registry.DeleteECR(ctx, a.awsConfig, a.resourceName)
 		if err != nil {
 			panic(err)
 		}

--- a/app/testutil/helper.go
+++ b/app/testutil/helper.go
@@ -54,8 +54,8 @@ func CreateDeployment(ctx context.Context, clientset *kubernetes.Clientset, name
 					},
 					Annotations: map[string]string{
 						"sidecar.istio.io/inject":                          "true",
-						"sidecar.istio.io/proxyCPULimit":                   params.IstioProxyCPU,
-						"sidecar.istio.io/proxyMemoryLimit":                params.IstioProxyMemory,
+						"sidecar.istio.io/proxyCPULimit":                   params.DefaultIstioProxyCPU,
+						"sidecar.istio.io/proxyMemoryLimit":                params.DefaultIstioProxyMemory,
 						"traffic.sidecar.istio.io/includeOutboundIPRanges": "*",
 						"proxy.istio.io/config":                            `{ "terminationDrainDuration": "30s" }`,
 					},
@@ -67,13 +67,13 @@ func CreateDeployment(ctx context.Context, clientset *kubernetes.Clientset, name
 							Image: "my-local-image:v1",
 							Ports: []corev1.ContainerPort{
 								{
-									ContainerPort: int32(params.PrismPort),
+									ContainerPort: int32(params.DefaultPrismPort),
 								},
 							},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse(params.PrismCPU),
-									corev1.ResourceMemory: resource.MustParse(params.PrismMemory),
+									corev1.ResourceCPU:    resource.MustParse(params.DefaultPrismCPU),
+									corev1.ResourceMemory: resource.MustParse(params.DefaultPrismMemory),
 								},
 							},
 						},

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.1
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
-	github.com/pingcap/errors v0.11.4
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 	gopkg.in/yaml.v2 v2.4.0
 	istio.io/api v1.22.3-0.20240703105953-437a88321a16
 	istio.io/client-go v1.22.3

--- a/go.sum
+++ b/go.sum
@@ -91,10 +91,6 @@ github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY
 github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
 github.com/onsi/gomega v1.31.0 h1:54UJxxj6cPInHS3a35wm6BK/F9nHYueZ1NVujHDrnXE=
 github.com/onsi/gomega v1.31.0/go.mod h1:DW9aCi7U6Yi40wNVAvT6kzFnEVEI5n3DloYBiKiT6zk=
-github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
-github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
@@ -153,8 +149,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto/googleapis/api v0.0.0-20241104194629-dd2ea8efbc28 h1:M0KvPgPmDZHPlbRbaNU1APr28TvwvvdUPlSv7PUvy8g=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,15 @@
 package main
 
-import "github.com/gold-kou/prism-in-k8s/app"
+import (
+	"log"
+
+	"github.com/gold-kou/prism-in-k8s/app"
+)
 
 func main() {
-	app.Run()
+	a, err := app.NewApp()
+	if err != nil {
+		log.Fatalf("failed to initialize app: %v", err)
+	}
+	a.Run()
 }


### PR DESCRIPTION
## Summary
- Remove package-level global variables and `init()` from `app/params/params.go` and `app/run.go`
- Introduce `App` struct in `run.go` with `NewApp()` constructor and `Run()` method
- Add `ApplyDefaults()` and `Validate()` methods on `*Config` instead of standalone functions
- Pass `*params.Config` explicitly to functions that need configuration

## Test plan
- [ ] `go build ./...` passes
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)