### PR TITLE
Add KEDA ScaledObject support for automatic Pod scale-down during off-hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ kedaMaxReplicas: "3"
 
 With this config, the Prism mock Pod is scaled to `0` outside the cron window (to save cost in non-production environments) and scales up to `kedaMaxReplicas` while CPU utilization exceeds 50% inside the window. KEDA evaluates the cron and CPU triggers in parallel and applies the higher requested replica count.
 
-Note: When `kedaMode` is `true`, KEDA must be installed in the target cluster. If the `ScaledObject` CRD is missing, `prism-in-k8s -create` fails fast with a clear error rather than leaving a half-created Deployment behind. After scaling down, KEDA's default `cooldownPeriod` (300 seconds) applies before the replica count drops to `kedaMinReplicas`.
+Note: When `kedaMode` is `true`, KEDA must be installed in the target cluster. If the `ScaledObject` CRD is missing, the KEDA step fails fast with a clear error; the Deployment, Service, and Namespace created by the preceding steps remain in the cluster, so re-run with `-delete` (or install KEDA and retry `-create`) to clean up. After scaling down, KEDA's default `cooldownPeriod` (300 seconds) applies before the replica count drops to `kedaMinReplicas`.
 
 # For developers
 Additional requirement when building from source:

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ $ prism-in-k8s -delete
 | `kedaCronTimezone`            | IANA timezone (e.g. `Asia/Tokyo`) used to evaluate the KEDA cron trigger. | `"Asia/Tokyo"`                 | No       |
 | `kedaCronStart`               | Cron expression marking the start of the desired-replicas window. | `"0 9 * * 1-5"`                | No       |
 | `kedaCronEnd`                 | Cron expression marking the end of the desired-replicas window. | `"0 21 * * 1-5"`               | No       |
-| `kedaDesiredReplicas`         | Replica count to scale to while the cron window is active. Must be a positive integer and `<= kedaMaxReplicas`. | `"1"`                          | No       |
-| `kedaCpuUtilization`          | CPU utilization (%) threshold for the KEDA CPU trigger. Must be within `[1, 100]`. | `"50"`                         | No       |
-| `kedaMinReplicas`             | Minimum replica count for the ScaledObject. Must be a non-negative integer and `<= kedaMaxReplicas`. | `"0"`                          | No       |
-| `kedaMaxReplicas`             | Maximum replica count for the ScaledObject. Must be a positive integer. | `"1"`                          | No       |
+| `kedaDesiredReplicas`         | Replica count to scale to while the cron window is active. Must be a positive integer and `<= kedaMaxReplicas`. | `1`                            | No       |
+| `kedaCpuUtilization`          | CPU utilization (%) threshold for the KEDA CPU trigger. Must be within `[1, 100]`. | `50`                           | No       |
+| `kedaMinReplicas`             | Minimum replica count for the ScaledObject. Must be a non-negative integer and `<= kedaMaxReplicas`. | `0`                            | No       |
+| `kedaMaxReplicas`             | Maximum replica count for the ScaledObject. Must be a positive integer. | `1`                            | No       |
 
 sample:
 
@@ -134,10 +134,10 @@ kedaMode: true
 kedaCronTimezone: "Asia/Tokyo"
 kedaCronStart: "0 9 * * 1-5"   # weekdays 09:00
 kedaCronEnd: "0 21 * * 1-5"    # weekdays 21:00
-kedaDesiredReplicas: "1"
-kedaCpuUtilization: "50"
-kedaMinReplicas: "0"
-kedaMaxReplicas: "3"
+kedaDesiredReplicas: 1
+kedaCpuUtilization: 50
+kedaMinReplicas: 0
+kedaMaxReplicas: 3
 ```
 
 With this config, the Prism mock Pod is scaled to `0` outside the cron window (to save cost in non-production environments) and scales up to `kedaMaxReplicas` while CPU utilization exceeds 50% inside the window. KEDA evaluates the cron and CPU triggers in parallel and applies the higher requested replica count.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ Beyond just creating Prism Pods, this tool automates the provisioning of:
 - AWS ECR
 - Kubernetes Namespace, Deployment, and Service
 - Istio VirtualService (allowing for advanced features like fault injection)
+- KEDA ScaledObject (optional, for CPU- and Cron-based Pod autoscaling)
 
 By configuring the VirtualService, you can introduce fixed delays using fault injection to create a more realistic testing environment.
+
+By configuring KEDA mode, you can scale the Prism Pod between configurable min/max replicas based on CPU utilization and a scheduled window (e.g. business hours), which helps reduce cost in non-production environments.
 
 # Prerequisites
 Before using this tool, ensure you have the following installed and configured:
@@ -80,6 +83,14 @@ $ prism-in-k8s -delete
 | `podAntiAffinityTopologyKey`  | Topology key for pod anti-affinity (e.g., `kubernetes.io/hostname`). Prevents multiple pods of the same service from running on the same topology | -                              | No       |
 | `ecrTags`                     | Pairs of ECR tag                          | -                              | No       |
 | `dockerBuildPlatform`         | Target platform passed to `docker build --platform` for the Prism image. Must be `linux/amd64` or `linux/arm64`. Set to `linux/arm64` when the destination cluster runs on Graviton (arm64) nodes. | `"linux/amd64"`                | No       |
+| `kedaMode`                    | Whether to create a KEDA ScaledObject for Pod autoscaling. Requires KEDA installed in the target cluster. | `false`                        | No       |
+| `kedaCronTimezone`            | IANA timezone (e.g. `Asia/Tokyo`) used to evaluate the KEDA cron trigger. | `"Asia/Tokyo"`                 | No       |
+| `kedaCronStart`               | Cron expression marking the start of the desired-replicas window. | `"0 9 * * 1-5"`                | No       |
+| `kedaCronEnd`                 | Cron expression marking the end of the desired-replicas window. | `"0 21 * * 1-5"`               | No       |
+| `kedaDesiredReplicas`         | Replica count to scale to while the cron window is active. Must be a positive integer and `<= kedaMaxReplicas`. | `"1"`                          | No       |
+| `kedaCpuUtilization`          | CPU utilization (%) threshold for the KEDA CPU trigger. Must be within `[1, 100]`. | `"50"`                         | No       |
+| `kedaMinReplicas`             | Minimum replica count for the ScaledObject. Must be a non-negative integer and `<= kedaMaxReplicas`. | `"0"`                          | No       |
+| `kedaMaxReplicas`             | Maximum replica count for the ScaledObject. Must be a positive integer. | `"1"`                          | No       |
 
 sample:
 
@@ -112,6 +123,26 @@ ecrTags:
 ```
 
 Note: `podAntiAffinityTopologyKey` uses `requiredDuringSchedulingIgnoredDuringExecution` with the `app` label of the deployed service as the label selector. This means it prevents multiple pods of the same Prism mock service from being scheduled on the same topology (e.g., same node).
+
+sample (with KEDA enabled):
+
+```
+microserviceName: "sample"
+microserviceNamespace: "sample"
+prismMockSuffix: "-prism-mock"
+kedaMode: true
+kedaCronTimezone: "Asia/Tokyo"
+kedaCronStart: "0 9 * * 1-5"   # weekdays 09:00
+kedaCronEnd: "0 21 * * 1-5"    # weekdays 21:00
+kedaDesiredReplicas: "1"
+kedaCpuUtilization: "50"
+kedaMinReplicas: "0"
+kedaMaxReplicas: "3"
+```
+
+With this config, the Prism mock Pod is scaled to `0` outside the cron window (to save cost in non-production environments) and scales up to `kedaMaxReplicas` while CPU utilization exceeds 50% inside the window. KEDA evaluates the cron and CPU triggers in parallel and applies the higher requested replica count.
+
+Note: When `kedaMode` is `true`, KEDA must be installed in the target cluster. If the `ScaledObject` CRD is missing, `prism-in-k8s -create` fails fast with a clear error rather than leaving a half-created Deployment behind. After scaling down, KEDA's default `cooldownPeriod` (300 seconds) applies before the replica count drops to `kedaMinReplicas`.
 
 # For developers
 Additional requirement when building from source:

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Beyond just creating Prism Pods, this tool automates the provisioning of:
 - AWS ECR
 - Kubernetes Namespace, Deployment, and Service
 - Istio VirtualService (allowing for advanced features like fault injection)
-- KEDA ScaledObject (optional, for CPU- and Cron-based Pod autoscaling)
+- KEDA ScaledObject (optional, for Cron-based Pod autoscaling)
 
 By configuring the VirtualService, you can introduce fixed delays using fault injection to create a more realistic testing environment.
 
-By configuring KEDA mode, you can scale the Prism Pod between configurable min/max replicas based on CPU utilization and a scheduled window (e.g. business hours), which helps reduce cost in non-production environments.
+By configuring KEDA mode, you can scale the Prism Pod between configurable min/max replicas based on a scheduled window (e.g. business hours), which helps reduce cost in non-production environments.
 
 # Prerequisites
 Before using this tool, ensure you have the following installed and configured:
@@ -88,7 +88,6 @@ $ prism-in-k8s -delete
 | `kedaCronStart`               | Cron expression marking the start of the desired-replicas window. | `"0 9 * * 1-5"`                | No       |
 | `kedaCronEnd`                 | Cron expression marking the end of the desired-replicas window. | `"0 21 * * 1-5"`               | No       |
 | `kedaDesiredReplicas`         | Replica count to scale to while the cron window is active. Must be a positive integer and `<= kedaMaxReplicas`. | `1`                            | No       |
-| `kedaCpuUtilization`          | CPU utilization (%) threshold for the KEDA CPU trigger. Must be within `[1, 100]`. | `50`                           | No       |
 | `kedaMinReplicas`             | Minimum replica count for the ScaledObject. Must be a non-negative integer and `<= kedaMaxReplicas`. | `0`                            | No       |
 | `kedaMaxReplicas`             | Maximum replica count for the ScaledObject. Must be a positive integer. | `1`                            | No       |
 
@@ -135,12 +134,11 @@ kedaCronTimezone: "Asia/Tokyo"
 kedaCronStart: "0 9 * * 1-5"   # weekdays 09:00
 kedaCronEnd: "0 21 * * 1-5"    # weekdays 21:00
 kedaDesiredReplicas: 1
-kedaCpuUtilization: 50
 kedaMinReplicas: 0
-kedaMaxReplicas: 3
+kedaMaxReplicas: 1
 ```
 
-With this config, the Prism mock Pod is scaled to `0` outside the cron window (to save cost in non-production environments) and scales up to `kedaMaxReplicas` while CPU utilization exceeds 50% inside the window. KEDA evaluates the cron and CPU triggers in parallel and applies the higher requested replica count.
+With this config, the Prism mock Pod is scaled to `0` outside the cron window (to save cost in non-production environments) and runs `kedaDesiredReplicas` Pod(s) inside the window.
 
 Note: When `kedaMode` is `true`, KEDA must be installed in the target cluster. If the `ScaledObject` CRD is missing, the KEDA step fails fast with a clear error; the Deployment, Service, and Namespace created by the preceding steps remain in the cluster, so re-run with `-delete` (or install KEDA and retry `-create`) to clean up. After scaling down, KEDA's default `cooldownPeriod` (300 seconds) applies before the replica count drops to `kedaMinReplicas`.
 

--- a/app/keda/keda.go
+++ b/app/keda/keda.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gold-kou/prism-in-k8s/app/params"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,9 +30,12 @@ func CreateKedaResources(ctx context.Context, cfg *params.Config, kubeconfig *re
 	}
 
 	// Fail fast if the KEDA ScaledObject CRD is not installed in the cluster.
-	// Permission or transient errors are deferred to the actual Create call below.
+	// dynamic client talks to the API server directly, so a missing CRD surfaces
+	// as a 404 NotFound from the server (apierrors.IsNotFound), not as a
+	// client-side RESTMapper error. Permission or transient errors are deferred
+	// to the actual Create call below.
 	if _, err := dynamicClient.Resource(scaledObjectGVR).Namespace(namespaceName).List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
-		if meta.IsNoMatchError(err) {
+		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("KEDA ScaledObject CRD is not installed in the cluster (kedaMode requires KEDA Operator): %w", err)
 		}
 	}

--- a/app/keda/keda.go
+++ b/app/keda/keda.go
@@ -78,8 +78,7 @@ func DeleteKedaResources(ctx context.Context, kubeconfig *restclient.Config, nam
 // Caller must have run cfg.Validate() so that KEDA numeric params are well-formed
 // and the invariants (min <= max, desired <= max) hold.
 func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Unstructured {
-	// KEDA trigger metadata expects string values, so convert the int params at the boundary.
-	cpuUtilization := strconv.Itoa(cfg.KedaCPUUtilization)
+	// KEDA trigger metadata expects string values, so convert the int param at the boundary.
 	desiredReplicas := strconv.Itoa(cfg.KedaDesiredReplicas)
 
 	scaledObject := &unstructured.Unstructured{
@@ -98,13 +97,6 @@ func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Un
 				"minReplicaCount": int64(cfg.KedaMinReplicas),
 				"maxReplicaCount": int64(cfg.KedaMaxReplicas),
 				"triggers": []map[string]interface{}{
-					{
-						"type":       "cpu",
-						"metricType": "Utilization",
-						metadataKey: map[string]interface{}{
-							"value": cpuUtilization,
-						},
-					},
 					{
 						"type": "cron",
 						metadataKey: map[string]interface{}{

--- a/app/keda/keda.go
+++ b/app/keda/keda.go
@@ -1,0 +1,96 @@
+package keda
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/gold-kou/prism-in-k8s/app/params"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	restclient "k8s.io/client-go/rest"
+)
+
+var scaledObjectGVR = schema.GroupVersionResource{
+	Group:    "keda.sh",
+	Version:  "v1alpha1",
+	Resource: "scaledobjects",
+}
+
+func CreateKedaResources(ctx context.Context, cfg *params.Config, kubeconfig *restclient.Config, namespaceName, resourceName string) error {
+	dynamicClient, err := dynamic.NewForConfig(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	scaledObject := BuildScaledObject(cfg, resourceName)
+
+	_, err = dynamicClient.Resource(scaledObjectGVR).Namespace(namespaceName).Create(ctx, scaledObject, metav1.CreateOptions{})
+	if err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create ScaledObject: %w", err)
+		}
+		slog.Warn("The ScaledObject already exists")
+	} else {
+		slog.Info("ScaledObject is created successfully")
+	}
+	return nil
+}
+
+func DeleteKedaResources(ctx context.Context, kubeconfig *restclient.Config, namespaceName, resourceName string) error {
+	dynamicClient, err := dynamic.NewForConfig(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	err = dynamicClient.Resource(scaledObjectGVR).Namespace(namespaceName).Delete(ctx, resourceName, metav1.DeleteOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete ScaledObject: %w", err)
+		}
+		slog.Warn("The ScaledObject is not found")
+	} else {
+		slog.Info("ScaledObject is deleted successfully")
+	}
+	return nil
+}
+
+func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Unstructured {
+	maxReplicas := int64(1)
+	if v, err := strconv.ParseInt(cfg.KedaDesiredReplicas, 10, 64); err == nil && v > maxReplicas {
+		maxReplicas = v
+	}
+
+	scaledObject := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "keda.sh/v1alpha1",
+			"kind":       "ScaledObject",
+			"metadata": map[string]interface{}{
+				"name": resourceName,
+			},
+			"spec": map[string]interface{}{
+				"scaleTargetRef": map[string]interface{}{
+					"name": resourceName,
+				},
+				"minReplicaCount": int64(0),
+				"maxReplicaCount": maxReplicas,
+				"triggers": []map[string]interface{}{
+					{
+						"type": "cron",
+						"metadata": map[string]interface{}{
+							"timezone":        cfg.KedaCronTimezone,
+							"start":           cfg.KedaCronStart,
+							"end":             cfg.KedaCronEnd,
+							"desiredReplicas": cfg.KedaDesiredReplicas,
+						},
+					},
+				},
+			},
+		},
+	}
+	return scaledObject
+}

--- a/app/keda/keda.go
+++ b/app/keda/keda.go
@@ -90,7 +90,9 @@ func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Un
 			},
 			"spec": map[string]interface{}{
 				"scaleTargetRef": map[string]interface{}{
-					"name": resourceName,
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"name":       resourceName,
 				},
 				"minReplicaCount": minReplicas,
 				"maxReplicaCount": maxReplicas,

--- a/app/keda/keda.go
+++ b/app/keda/keda.go
@@ -29,14 +29,16 @@ func CreateKedaResources(ctx context.Context, cfg *params.Config, kubeconfig *re
 		return fmt.Errorf("failed to create dynamic client: %w", err)
 	}
 
-	// Fail fast if the KEDA ScaledObject CRD is not installed in the cluster.
-	// dynamic client talks to the API server directly, so a missing CRD surfaces
-	// as a 404 NotFound from the server (apierrors.IsNotFound), not as a
-	// client-side RESTMapper error. Permission or transient errors are deferred
-	// to the actual Create call below.
+	// Fail fast when the API server returns 404 for the ScaledObject resource.
+	// dynamic client talks to the API server directly via the GVR, so a missing
+	// CRD surfaces as apierrors.IsNotFound here (not as a client-side
+	// RESTMapper error). A missing namespace would also produce 404, but in
+	// this call path the namespace is created beforehand by k8s.CreateK8sResources,
+	// so a 404 most likely means KEDA itself is not installed. Permission or
+	// transient errors are deferred to the Create call below.
 	if _, err := dynamicClient.Resource(scaledObjectGVR).Namespace(namespaceName).List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
 		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("KEDA ScaledObject CRD is not installed in the cluster (kedaMode requires KEDA Operator): %w", err)
+			return fmt.Errorf("KEDA ScaledObject CRD or namespace %q not found; kedaMode requires KEDA Operator installed in the cluster: %w", namespaceName, err)
 		}
 	}
 

--- a/app/keda/keda.go
+++ b/app/keda/keda.go
@@ -78,8 +78,9 @@ func DeleteKedaResources(ctx context.Context, kubeconfig *restclient.Config, nam
 // Caller must have run cfg.Validate() so that KEDA numeric params are well-formed
 // and the invariants (min <= max, desired <= max) hold.
 func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Unstructured {
-	minReplicas, _ := strconv.ParseInt(cfg.KedaMinReplicas, 10, 64)
-	maxReplicas, _ := strconv.ParseInt(cfg.KedaMaxReplicas, 10, 64)
+	// KEDA trigger metadata expects string values, so convert the int params at the boundary.
+	cpuUtilization := strconv.Itoa(cfg.KedaCPUUtilization)
+	desiredReplicas := strconv.Itoa(cfg.KedaDesiredReplicas)
 
 	scaledObject := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -94,14 +95,14 @@ func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Un
 					"kind":       "Deployment",
 					"name":       resourceName,
 				},
-				"minReplicaCount": minReplicas,
-				"maxReplicaCount": maxReplicas,
+				"minReplicaCount": int64(cfg.KedaMinReplicas),
+				"maxReplicaCount": int64(cfg.KedaMaxReplicas),
 				"triggers": []map[string]interface{}{
 					{
 						"type":       "cpu",
 						"metricType": "Utilization",
 						metadataKey: map[string]interface{}{
-							"value": cfg.KedaCPUUtilization,
+							"value": cpuUtilization,
 						},
 					},
 					{
@@ -110,7 +111,7 @@ func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Un
 							"timezone":        cfg.KedaCronTimezone,
 							"start":           cfg.KedaCronStart,
 							"end":             cfg.KedaCronEnd,
-							"desiredReplicas": cfg.KedaDesiredReplicas,
+							"desiredReplicas": desiredReplicas,
 						},
 					},
 				},

--- a/app/keda/keda.go
+++ b/app/keda/keda.go
@@ -8,12 +8,15 @@ import (
 
 	"github.com/gold-kou/prism-in-k8s/app/params"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	restclient "k8s.io/client-go/rest"
 )
+
+const metadataKey = "metadata"
 
 var scaledObjectGVR = schema.GroupVersionResource{
 	Group:    "keda.sh",
@@ -27,16 +30,24 @@ func CreateKedaResources(ctx context.Context, cfg *params.Config, kubeconfig *re
 		return fmt.Errorf("failed to create dynamic client: %w", err)
 	}
 
+	// Fail fast if the KEDA ScaledObject CRD is not installed in the cluster.
+	// Permission or transient errors are deferred to the actual Create call below.
+	if _, err := dynamicClient.Resource(scaledObjectGVR).Namespace(namespaceName).List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
+		if meta.IsNoMatchError(err) {
+			return fmt.Errorf("KEDA ScaledObject CRD is not installed in the cluster (kedaMode requires KEDA Operator): %w", err)
+		}
+	}
+
 	scaledObject := BuildScaledObject(cfg, resourceName)
 
 	_, err = dynamicClient.Resource(scaledObjectGVR).Namespace(namespaceName).Create(ctx, scaledObject, metav1.CreateOptions{})
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create ScaledObject: %w", err)
+			return fmt.Errorf("failed to create ScaledObject %s/%s: %w", namespaceName, resourceName, err)
 		}
-		slog.Warn("The ScaledObject already exists")
+		slog.Warn("The ScaledObject already exists", "namespace", namespaceName, "resourceName", resourceName)
 	} else {
-		slog.Info("ScaledObject is created successfully")
+		slog.Info("ScaledObject is created successfully", "namespace", namespaceName, "resourceName", resourceName)
 	}
 	return nil
 }
@@ -50,34 +61,27 @@ func DeleteKedaResources(ctx context.Context, kubeconfig *restclient.Config, nam
 	err = dynamicClient.Resource(scaledObjectGVR).Namespace(namespaceName).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete ScaledObject: %w", err)
+			return fmt.Errorf("failed to delete ScaledObject %s/%s: %w", namespaceName, resourceName, err)
 		}
-		slog.Warn("The ScaledObject is not found")
+		slog.Warn("The ScaledObject is not found", "namespace", namespaceName, "resourceName", resourceName)
 	} else {
-		slog.Info("ScaledObject is deleted successfully")
+		slog.Info("ScaledObject is deleted successfully", "namespace", namespaceName, "resourceName", resourceName)
 	}
 	return nil
 }
 
+// BuildScaledObject constructs the ScaledObject manifest from cfg.
+// Caller must have run cfg.Validate() so that KEDA numeric params are well-formed
+// and the invariants (min <= max, desired <= max) hold.
 func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Unstructured {
-	minReplicas := int64(0)
-	if v, err := strconv.ParseInt(cfg.KedaMinReplicas, 10, 64); err == nil && v >= 0 {
-		minReplicas = v
-	}
-
-	maxReplicas := int64(1)
-	if v, err := strconv.ParseInt(cfg.KedaMaxReplicas, 10, 64); err == nil && v > 0 {
-		maxReplicas = v
-	}
-	if v, err := strconv.ParseInt(cfg.KedaDesiredReplicas, 10, 64); err == nil && v > maxReplicas {
-		maxReplicas = v
-	}
+	minReplicas, _ := strconv.ParseInt(cfg.KedaMinReplicas, 10, 64)
+	maxReplicas, _ := strconv.ParseInt(cfg.KedaMaxReplicas, 10, 64)
 
 	scaledObject := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "keda.sh/v1alpha1",
 			"kind":       "ScaledObject",
-			"metadata": map[string]interface{}{
+			metadataKey: map[string]interface{}{
 				"name": resourceName,
 			},
 			"spec": map[string]interface{}{
@@ -90,13 +94,13 @@ func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Un
 					{
 						"type":       "cpu",
 						"metricType": "Utilization",
-						"metadata": map[string]interface{}{
+						metadataKey: map[string]interface{}{
 							"value": cfg.KedaCPUUtilization,
 						},
 					},
 					{
 						"type": "cron",
-						"metadata": map[string]interface{}{
+						metadataKey: map[string]interface{}{
 							"timezone":        cfg.KedaCronTimezone,
 							"start":           cfg.KedaCronStart,
 							"end":             cfg.KedaCronEnd,

--- a/app/keda/keda.go
+++ b/app/keda/keda.go
@@ -15,8 +15,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
-const metadataKey = "metadata"
-
 var scaledObjectGVR = schema.GroupVersionResource{
 	Group:    "keda.sh",
 	Version:  "v1alpha1",
@@ -86,7 +84,7 @@ func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Un
 		Object: map[string]interface{}{
 			"apiVersion": "keda.sh/v1alpha1",
 			"kind":       "ScaledObject",
-			metadataKey: map[string]interface{}{
+			"metadata": map[string]interface{}{
 				"name": resourceName,
 			},
 			"spec": map[string]interface{}{
@@ -100,7 +98,7 @@ func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Un
 				"triggers": []map[string]interface{}{
 					{
 						"type": "cron",
-						metadataKey: map[string]interface{}{
+						"metadata": map[string]interface{}{
 							"timezone":        cfg.KedaCronTimezone,
 							"start":           cfg.KedaCronStart,
 							"end":             cfg.KedaCronEnd,

--- a/app/keda/keda.go
+++ b/app/keda/keda.go
@@ -40,6 +40,7 @@ func CreateKedaResources(ctx context.Context, cfg *params.Config, kubeconfig *re
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("KEDA ScaledObject CRD or namespace %q not found; kedaMode requires KEDA Operator installed in the cluster: %w", namespaceName, err)
 		}
+		slog.Warn("Failed to list ScaledObject during pre-flight check; deferring to Create", "namespace", namespaceName, "error", err)
 	}
 
 	scaledObject := BuildScaledObject(cfg, resourceName)

--- a/app/keda/keda.go
+++ b/app/keda/keda.go
@@ -60,7 +60,15 @@ func DeleteKedaResources(ctx context.Context, kubeconfig *restclient.Config, nam
 }
 
 func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Unstructured {
+	minReplicas := int64(0)
+	if v, err := strconv.ParseInt(cfg.KedaMinReplicas, 10, 64); err == nil && v >= 0 {
+		minReplicas = v
+	}
+
 	maxReplicas := int64(1)
+	if v, err := strconv.ParseInt(cfg.KedaMaxReplicas, 10, 64); err == nil && v > 0 {
+		maxReplicas = v
+	}
 	if v, err := strconv.ParseInt(cfg.KedaDesiredReplicas, 10, 64); err == nil && v > maxReplicas {
 		maxReplicas = v
 	}
@@ -76,9 +84,16 @@ func BuildScaledObject(cfg *params.Config, resourceName string) *unstructured.Un
 				"scaleTargetRef": map[string]interface{}{
 					"name": resourceName,
 				},
-				"minReplicaCount": int64(0),
+				"minReplicaCount": minReplicas,
 				"maxReplicaCount": maxReplicas,
 				"triggers": []map[string]interface{}{
+					{
+						"type":       "cpu",
+						"metricType": "Utilization",
+						"metadata": map[string]interface{}{
+							"value": cfg.KedaCPUUtilization,
+						},
+					},
 					{
 						"type": "cron",
 						"metadata": map[string]interface{}{

--- a/app/keda/keda_test.go
+++ b/app/keda/keda_test.go
@@ -15,6 +15,9 @@ func TestBuildScaledObject(t *testing.T) {
 		KedaCronStart:       "0 9 * * 1-5",
 		KedaCronEnd:         "0 21 * * 1-5",
 		KedaDesiredReplicas: "1",
+		KedaCPUUtilization:  "50",
+		KedaMinReplicas:     "0",
+		KedaMaxReplicas:     "1",
 	}
 
 	resourceName := "test-service-prism-mock"
@@ -45,17 +48,26 @@ func TestBuildScaledObject(t *testing.T) {
 	// verify triggers
 	triggers, ok := spec["triggers"].([]map[string]interface{})
 	require.True(t, ok)
-	require.Len(t, triggers, 1)
+	require.Len(t, triggers, 2)
 
-	trigger := triggers[0]
-	assert.Equal(t, "cron", trigger["type"])
-
-	triggerMetadata, ok := trigger["metadata"].(map[string]interface{})
+	// CPU trigger (index 0)
+	cpuTrigger := triggers[0]
+	assert.Equal(t, "cpu", cpuTrigger["type"])
+	assert.Equal(t, "Utilization", cpuTrigger["metricType"])
+	cpuMetadata, ok := cpuTrigger["metadata"].(map[string]interface{})
 	require.True(t, ok)
-	assert.Equal(t, "Asia/Tokyo", triggerMetadata["timezone"])
-	assert.Equal(t, "0 9 * * 1-5", triggerMetadata["start"])
-	assert.Equal(t, "0 21 * * 1-5", triggerMetadata["end"])
-	assert.Equal(t, "1", triggerMetadata["desiredReplicas"])
+	assert.Equal(t, "50", cpuMetadata["value"])
+
+	// Cron trigger (index 1)
+	cronTrigger := triggers[1]
+	assert.Equal(t, "cron", cronTrigger["type"])
+
+	cronMetadata, ok := cronTrigger["metadata"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "Asia/Tokyo", cronMetadata["timezone"])
+	assert.Equal(t, "0 9 * * 1-5", cronMetadata["start"])
+	assert.Equal(t, "0 21 * * 1-5", cronMetadata["end"])
+	assert.Equal(t, "1", cronMetadata["desiredReplicas"])
 }
 
 func TestBuildScaledObject_MaxReplicasMatchesDesired(t *testing.T) {
@@ -64,11 +76,57 @@ func TestBuildScaledObject_MaxReplicasMatchesDesired(t *testing.T) {
 		KedaCronStart:       "0 9 * * 1-5",
 		KedaCronEnd:         "0 21 * * 1-5",
 		KedaDesiredReplicas: "3",
+		KedaCPUUtilization:  "50",
+		KedaMinReplicas:     "0",
+		KedaMaxReplicas:     "1",
 	}
 
 	scaledObject := keda.BuildScaledObject(cfg, "test-resource")
 	spec, ok := scaledObject.Object["spec"].(map[string]interface{})
 	require.True(t, ok)
 
-	assert.Equal(t, int64(3), spec["maxReplicaCount"], "maxReplicaCount should match desiredReplicas when > 1")
+	assert.Equal(t, int64(3), spec["maxReplicaCount"], "maxReplicaCount should be raised to desiredReplicas when desired > max")
+}
+
+func TestBuildScaledObject_CustomMinMaxReplicas(t *testing.T) {
+	cfg := &params.Config{
+		KedaCronTimezone:    "Asia/Tokyo",
+		KedaCronStart:       "0 9 * * 1-5",
+		KedaCronEnd:         "0 21 * * 1-5",
+		KedaDesiredReplicas: "2",
+		KedaCPUUtilization:  "50",
+		KedaMinReplicas:     "1",
+		KedaMaxReplicas:     "5",
+	}
+
+	scaledObject := keda.BuildScaledObject(cfg, "test-resource")
+	spec, ok := scaledObject.Object["spec"].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, int64(1), spec["minReplicaCount"], "minReplicaCount should reflect KedaMinReplicas")
+	assert.Equal(t, int64(5), spec["maxReplicaCount"], "maxReplicaCount should reflect KedaMaxReplicas when desired < max")
+}
+
+func TestBuildScaledObject_CustomCPUUtilization(t *testing.T) {
+	cfg := &params.Config{
+		KedaCronTimezone:    "Asia/Tokyo",
+		KedaCronStart:       "0 9 * * 1-5",
+		KedaCronEnd:         "0 21 * * 1-5",
+		KedaDesiredReplicas: "1",
+		KedaCPUUtilization:  "75",
+		KedaMinReplicas:     "0",
+		KedaMaxReplicas:     "1",
+	}
+
+	scaledObject := keda.BuildScaledObject(cfg, "test-resource")
+	spec, ok := scaledObject.Object["spec"].(map[string]interface{})
+	require.True(t, ok)
+
+	triggers, ok := spec["triggers"].([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, triggers, 2)
+
+	cpuMetadata, ok := triggers[0]["metadata"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "75", cpuMetadata["value"], "CPU value should reflect configured KedaCPUUtilization")
 }

--- a/app/keda/keda_test.go
+++ b/app/keda/keda_test.go
@@ -21,7 +21,6 @@ func TestBuildScaledObject(t *testing.T) {
 		KedaCronStart:       testCronStart,
 		KedaCronEnd:         testCronEnd,
 		KedaDesiredReplicas: 1,
-		KedaCPUUtilization:  50,
 		KedaMinReplicas:     0,
 		KedaMaxReplicas:     1,
 	}
@@ -53,21 +52,12 @@ func TestBuildScaledObject(t *testing.T) {
 	assert.Equal(t, int64(0), spec["minReplicaCount"])
 	assert.Equal(t, int64(1), spec["maxReplicaCount"])
 
-	// verify triggers
+	// verify triggers (cron-only)
 	triggers, isSlice := spec["triggers"].([]map[string]interface{})
 	require.True(t, isSlice)
-	require.Len(t, triggers, 2)
+	require.Len(t, triggers, 1)
 
-	// CPU trigger (index 0)
-	cpuTrigger := triggers[0]
-	assert.Equal(t, "cpu", cpuTrigger["type"])
-	assert.Equal(t, "Utilization", cpuTrigger["metricType"])
-	cpuMetadata, isMap := cpuTrigger["metadata"].(map[string]interface{})
-	require.True(t, isMap)
-	assert.Equal(t, "50", cpuMetadata["value"])
-
-	// Cron trigger (index 1)
-	cronTrigger := triggers[1]
+	cronTrigger := triggers[0]
 	assert.Equal(t, "cron", cronTrigger["type"])
 
 	cronMetadata, isMap := cronTrigger["metadata"].(map[string]interface{})
@@ -86,7 +76,6 @@ func TestBuildScaledObject_DesiredAndMaxEqual(t *testing.T) {
 		KedaCronStart:       testCronStart,
 		KedaCronEnd:         testCronEnd,
 		KedaDesiredReplicas: 3,
-		KedaCPUUtilization:  50,
 		KedaMinReplicas:     0,
 		KedaMaxReplicas:     3,
 	}
@@ -104,7 +93,6 @@ func TestBuildScaledObject_CustomMinMaxReplicas(t *testing.T) {
 		KedaCronStart:       testCronStart,
 		KedaCronEnd:         testCronEnd,
 		KedaDesiredReplicas: 2,
-		KedaCPUUtilization:  50,
 		KedaMinReplicas:     1,
 		KedaMaxReplicas:     5,
 	}
@@ -115,28 +103,4 @@ func TestBuildScaledObject_CustomMinMaxReplicas(t *testing.T) {
 
 	assert.Equal(t, int64(1), spec["minReplicaCount"], "minReplicaCount should reflect KedaMinReplicas")
 	assert.Equal(t, int64(5), spec["maxReplicaCount"], "maxReplicaCount should reflect KedaMaxReplicas when desired < max")
-}
-
-func TestBuildScaledObject_CustomCPUUtilization(t *testing.T) {
-	cfg := &params.Config{
-		KedaCronTimezone:    testTimezone,
-		KedaCronStart:       testCronStart,
-		KedaCronEnd:         testCronEnd,
-		KedaDesiredReplicas: 1,
-		KedaCPUUtilization:  75,
-		KedaMinReplicas:     0,
-		KedaMaxReplicas:     1,
-	}
-
-	scaledObject := keda.BuildScaledObject(cfg, "test-resource")
-	spec, isMap := scaledObject.Object["spec"].(map[string]interface{})
-	require.True(t, isMap)
-
-	triggers, isSlice := spec["triggers"].([]map[string]interface{})
-	require.True(t, isSlice)
-	require.Len(t, triggers, 2)
-
-	cpuMetadata, isMap := triggers[0]["metadata"].(map[string]interface{})
-	require.True(t, isMap)
-	assert.Equal(t, "75", cpuMetadata["value"], "CPU value should reflect configured KedaCPUUtilization")
 }

--- a/app/keda/keda_test.go
+++ b/app/keda/keda_test.go
@@ -46,6 +46,8 @@ func TestBuildScaledObject(t *testing.T) {
 
 	scaleTargetRef, isMap := spec["scaleTargetRef"].(map[string]interface{})
 	require.True(t, isMap)
+	assert.Equal(t, "apps/v1", scaleTargetRef["apiVersion"])
+	assert.Equal(t, "Deployment", scaleTargetRef["kind"])
 	assert.Equal(t, resourceName, scaleTargetRef["name"])
 
 	assert.Equal(t, int64(0), spec["minReplicaCount"])

--- a/app/keda/keda_test.go
+++ b/app/keda/keda_test.go
@@ -9,11 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testTimezone  = "Asia/Tokyo"
+	testCronStart = "0 9 * * 1-5"
+	testCronEnd   = "0 21 * * 1-5"
+)
+
 func TestBuildScaledObject(t *testing.T) {
 	cfg := &params.Config{
-		KedaCronTimezone:    "Asia/Tokyo",
-		KedaCronStart:       "0 9 * * 1-5",
-		KedaCronEnd:         "0 21 * * 1-5",
+		KedaCronTimezone:    testTimezone,
+		KedaCronStart:       testCronStart,
+		KedaCronEnd:         testCronEnd,
 		KedaDesiredReplicas: "1",
 		KedaCPUUtilization:  "50",
 		KedaMinReplicas:     "0",
@@ -30,69 +36,71 @@ func TestBuildScaledObject(t *testing.T) {
 	assert.Equal(t, "ScaledObject", scaledObject.Object["kind"])
 
 	// verify metadata
-	metadata, ok := scaledObject.Object["metadata"].(map[string]interface{})
-	require.True(t, ok)
+	metadata, isMap := scaledObject.Object["metadata"].(map[string]interface{})
+	require.True(t, isMap)
 	assert.Equal(t, resourceName, metadata["name"])
 
 	// verify spec
-	spec, ok := scaledObject.Object["spec"].(map[string]interface{})
-	require.True(t, ok)
+	spec, isMap := scaledObject.Object["spec"].(map[string]interface{})
+	require.True(t, isMap)
 
-	scaleTargetRef, ok := spec["scaleTargetRef"].(map[string]interface{})
-	require.True(t, ok)
+	scaleTargetRef, isMap := spec["scaleTargetRef"].(map[string]interface{})
+	require.True(t, isMap)
 	assert.Equal(t, resourceName, scaleTargetRef["name"])
 
 	assert.Equal(t, int64(0), spec["minReplicaCount"])
 	assert.Equal(t, int64(1), spec["maxReplicaCount"])
 
 	// verify triggers
-	triggers, ok := spec["triggers"].([]map[string]interface{})
-	require.True(t, ok)
+	triggers, isSlice := spec["triggers"].([]map[string]interface{})
+	require.True(t, isSlice)
 	require.Len(t, triggers, 2)
 
 	// CPU trigger (index 0)
 	cpuTrigger := triggers[0]
 	assert.Equal(t, "cpu", cpuTrigger["type"])
 	assert.Equal(t, "Utilization", cpuTrigger["metricType"])
-	cpuMetadata, ok := cpuTrigger["metadata"].(map[string]interface{})
-	require.True(t, ok)
+	cpuMetadata, isMap := cpuTrigger["metadata"].(map[string]interface{})
+	require.True(t, isMap)
 	assert.Equal(t, "50", cpuMetadata["value"])
 
 	// Cron trigger (index 1)
 	cronTrigger := triggers[1]
 	assert.Equal(t, "cron", cronTrigger["type"])
 
-	cronMetadata, ok := cronTrigger["metadata"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "Asia/Tokyo", cronMetadata["timezone"])
-	assert.Equal(t, "0 9 * * 1-5", cronMetadata["start"])
-	assert.Equal(t, "0 21 * * 1-5", cronMetadata["end"])
+	cronMetadata, isMap := cronTrigger["metadata"].(map[string]interface{})
+	require.True(t, isMap)
+	assert.Equal(t, testTimezone, cronMetadata["timezone"])
+	assert.Equal(t, testCronStart, cronMetadata["start"])
+	assert.Equal(t, testCronEnd, cronMetadata["end"])
 	assert.Equal(t, "1", cronMetadata["desiredReplicas"])
 }
 
-func TestBuildScaledObject_MaxReplicasMatchesDesired(t *testing.T) {
+func TestBuildScaledObject_DesiredAndMaxEqual(t *testing.T) {
+	// Validate() guarantees desired <= max, so callers can simply set
+	// KedaMaxReplicas to match KedaDesiredReplicas when desired > 1.
 	cfg := &params.Config{
-		KedaCronTimezone:    "Asia/Tokyo",
-		KedaCronStart:       "0 9 * * 1-5",
-		KedaCronEnd:         "0 21 * * 1-5",
+		KedaCronTimezone:    testTimezone,
+		KedaCronStart:       testCronStart,
+		KedaCronEnd:         testCronEnd,
 		KedaDesiredReplicas: "3",
 		KedaCPUUtilization:  "50",
 		KedaMinReplicas:     "0",
-		KedaMaxReplicas:     "1",
+		KedaMaxReplicas:     "3",
 	}
 
 	scaledObject := keda.BuildScaledObject(cfg, "test-resource")
-	spec, ok := scaledObject.Object["spec"].(map[string]interface{})
-	require.True(t, ok)
+	spec, isMap := scaledObject.Object["spec"].(map[string]interface{})
+	require.True(t, isMap)
 
-	assert.Equal(t, int64(3), spec["maxReplicaCount"], "maxReplicaCount should be raised to desiredReplicas when desired > max")
+	assert.Equal(t, int64(3), spec["maxReplicaCount"])
 }
 
 func TestBuildScaledObject_CustomMinMaxReplicas(t *testing.T) {
 	cfg := &params.Config{
-		KedaCronTimezone:    "Asia/Tokyo",
-		KedaCronStart:       "0 9 * * 1-5",
-		KedaCronEnd:         "0 21 * * 1-5",
+		KedaCronTimezone:    testTimezone,
+		KedaCronStart:       testCronStart,
+		KedaCronEnd:         testCronEnd,
 		KedaDesiredReplicas: "2",
 		KedaCPUUtilization:  "50",
 		KedaMinReplicas:     "1",
@@ -100,8 +108,8 @@ func TestBuildScaledObject_CustomMinMaxReplicas(t *testing.T) {
 	}
 
 	scaledObject := keda.BuildScaledObject(cfg, "test-resource")
-	spec, ok := scaledObject.Object["spec"].(map[string]interface{})
-	require.True(t, ok)
+	spec, isMap := scaledObject.Object["spec"].(map[string]interface{})
+	require.True(t, isMap)
 
 	assert.Equal(t, int64(1), spec["minReplicaCount"], "minReplicaCount should reflect KedaMinReplicas")
 	assert.Equal(t, int64(5), spec["maxReplicaCount"], "maxReplicaCount should reflect KedaMaxReplicas when desired < max")
@@ -109,9 +117,9 @@ func TestBuildScaledObject_CustomMinMaxReplicas(t *testing.T) {
 
 func TestBuildScaledObject_CustomCPUUtilization(t *testing.T) {
 	cfg := &params.Config{
-		KedaCronTimezone:    "Asia/Tokyo",
-		KedaCronStart:       "0 9 * * 1-5",
-		KedaCronEnd:         "0 21 * * 1-5",
+		KedaCronTimezone:    testTimezone,
+		KedaCronStart:       testCronStart,
+		KedaCronEnd:         testCronEnd,
 		KedaDesiredReplicas: "1",
 		KedaCPUUtilization:  "75",
 		KedaMinReplicas:     "0",
@@ -119,14 +127,14 @@ func TestBuildScaledObject_CustomCPUUtilization(t *testing.T) {
 	}
 
 	scaledObject := keda.BuildScaledObject(cfg, "test-resource")
-	spec, ok := scaledObject.Object["spec"].(map[string]interface{})
-	require.True(t, ok)
+	spec, isMap := scaledObject.Object["spec"].(map[string]interface{})
+	require.True(t, isMap)
 
-	triggers, ok := spec["triggers"].([]map[string]interface{})
-	require.True(t, ok)
+	triggers, isSlice := spec["triggers"].([]map[string]interface{})
+	require.True(t, isSlice)
 	require.Len(t, triggers, 2)
 
-	cpuMetadata, ok := triggers[0]["metadata"].(map[string]interface{})
-	require.True(t, ok)
+	cpuMetadata, isMap := triggers[0]["metadata"].(map[string]interface{})
+	require.True(t, isMap)
 	assert.Equal(t, "75", cpuMetadata["value"], "CPU value should reflect configured KedaCPUUtilization")
 }

--- a/app/keda/keda_test.go
+++ b/app/keda/keda_test.go
@@ -20,10 +20,10 @@ func TestBuildScaledObject(t *testing.T) {
 		KedaCronTimezone:    testTimezone,
 		KedaCronStart:       testCronStart,
 		KedaCronEnd:         testCronEnd,
-		KedaDesiredReplicas: "1",
-		KedaCPUUtilization:  "50",
-		KedaMinReplicas:     "0",
-		KedaMaxReplicas:     "1",
+		KedaDesiredReplicas: 1,
+		KedaCPUUtilization:  50,
+		KedaMinReplicas:     0,
+		KedaMaxReplicas:     1,
 	}
 
 	resourceName := "test-service-prism-mock"
@@ -85,10 +85,10 @@ func TestBuildScaledObject_DesiredAndMaxEqual(t *testing.T) {
 		KedaCronTimezone:    testTimezone,
 		KedaCronStart:       testCronStart,
 		KedaCronEnd:         testCronEnd,
-		KedaDesiredReplicas: "3",
-		KedaCPUUtilization:  "50",
-		KedaMinReplicas:     "0",
-		KedaMaxReplicas:     "3",
+		KedaDesiredReplicas: 3,
+		KedaCPUUtilization:  50,
+		KedaMinReplicas:     0,
+		KedaMaxReplicas:     3,
 	}
 
 	scaledObject := keda.BuildScaledObject(cfg, "test-resource")
@@ -103,10 +103,10 @@ func TestBuildScaledObject_CustomMinMaxReplicas(t *testing.T) {
 		KedaCronTimezone:    testTimezone,
 		KedaCronStart:       testCronStart,
 		KedaCronEnd:         testCronEnd,
-		KedaDesiredReplicas: "2",
-		KedaCPUUtilization:  "50",
-		KedaMinReplicas:     "1",
-		KedaMaxReplicas:     "5",
+		KedaDesiredReplicas: 2,
+		KedaCPUUtilization:  50,
+		KedaMinReplicas:     1,
+		KedaMaxReplicas:     5,
 	}
 
 	scaledObject := keda.BuildScaledObject(cfg, "test-resource")
@@ -122,10 +122,10 @@ func TestBuildScaledObject_CustomCPUUtilization(t *testing.T) {
 		KedaCronTimezone:    testTimezone,
 		KedaCronStart:       testCronStart,
 		KedaCronEnd:         testCronEnd,
-		KedaDesiredReplicas: "1",
-		KedaCPUUtilization:  "75",
-		KedaMinReplicas:     "0",
-		KedaMaxReplicas:     "1",
+		KedaDesiredReplicas: 1,
+		KedaCPUUtilization:  75,
+		KedaMinReplicas:     0,
+		KedaMaxReplicas:     1,
 	}
 
 	scaledObject := keda.BuildScaledObject(cfg, "test-resource")

--- a/app/keda/keda_test.go
+++ b/app/keda/keda_test.go
@@ -1,0 +1,74 @@
+package keda_test
+
+import (
+	"testing"
+
+	"github.com/gold-kou/prism-in-k8s/app/keda"
+	"github.com/gold-kou/prism-in-k8s/app/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildScaledObject(t *testing.T) {
+	cfg := &params.Config{
+		KedaCronTimezone:    "Asia/Tokyo",
+		KedaCronStart:       "0 9 * * 1-5",
+		KedaCronEnd:         "0 21 * * 1-5",
+		KedaDesiredReplicas: "1",
+	}
+
+	resourceName := "test-service-prism-mock"
+
+	scaledObject := keda.BuildScaledObject(cfg, resourceName)
+	require.NotNil(t, scaledObject)
+
+	// verify top-level fields
+	assert.Equal(t, "keda.sh/v1alpha1", scaledObject.Object["apiVersion"])
+	assert.Equal(t, "ScaledObject", scaledObject.Object["kind"])
+
+	// verify metadata
+	metadata, ok := scaledObject.Object["metadata"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, resourceName, metadata["name"])
+
+	// verify spec
+	spec, ok := scaledObject.Object["spec"].(map[string]interface{})
+	require.True(t, ok)
+
+	scaleTargetRef, ok := spec["scaleTargetRef"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, resourceName, scaleTargetRef["name"])
+
+	assert.Equal(t, int64(0), spec["minReplicaCount"])
+	assert.Equal(t, int64(1), spec["maxReplicaCount"])
+
+	// verify triggers
+	triggers, ok := spec["triggers"].([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, triggers, 1)
+
+	trigger := triggers[0]
+	assert.Equal(t, "cron", trigger["type"])
+
+	triggerMetadata, ok := trigger["metadata"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "Asia/Tokyo", triggerMetadata["timezone"])
+	assert.Equal(t, "0 9 * * 1-5", triggerMetadata["start"])
+	assert.Equal(t, "0 21 * * 1-5", triggerMetadata["end"])
+	assert.Equal(t, "1", triggerMetadata["desiredReplicas"])
+}
+
+func TestBuildScaledObject_MaxReplicasMatchesDesired(t *testing.T) {
+	cfg := &params.Config{
+		KedaCronTimezone:    "Asia/Tokyo",
+		KedaCronStart:       "0 9 * * 1-5",
+		KedaCronEnd:         "0 21 * * 1-5",
+		KedaDesiredReplicas: "3",
+	}
+
+	scaledObject := keda.BuildScaledObject(cfg, "test-resource")
+	spec, ok := scaledObject.Object["spec"].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, int64(3), spec["maxReplicaCount"], "maxReplicaCount should match desiredReplicas when > 1")
+}

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -21,10 +20,10 @@ const (
 	defaultKedaCronTimezone    = "Asia/Tokyo"
 	defaultKedaCronStart       = "0 9 * * 1-5"
 	defaultKedaCronEnd         = "0 21 * * 1-5"
-	defaultKedaDesiredReplicas = "1"
-	defaultKedaCPUUtilization  = "50"
-	defaultKedaMinReplicas     = "0"
-	defaultKedaMaxReplicas     = "1"
+	defaultKedaDesiredReplicas = 1
+	defaultKedaCPUUtilization  = 50
+	defaultKedaMinReplicas     = 0
+	defaultKedaMaxReplicas     = 1
 	maxDelayPercentage         = 100.0
 )
 
@@ -65,10 +64,10 @@ type Config struct {
 	KedaCronTimezone             string                        `yaml:"kedaCronTimezone"`
 	KedaCronStart                string                        `yaml:"kedaCronStart"`
 	KedaCronEnd                  string                        `yaml:"kedaCronEnd"`
-	KedaDesiredReplicas          string                        `yaml:"kedaDesiredReplicas"`
-	KedaCPUUtilization           string                        `yaml:"kedaCpuUtilization"`
-	KedaMinReplicas              string                        `yaml:"kedaMinReplicas"`
-	KedaMaxReplicas              string                        `yaml:"kedaMaxReplicas"`
+	KedaDesiredReplicas          int                           `yaml:"kedaDesiredReplicas"`
+	KedaCPUUtilization           int                           `yaml:"kedaCpuUtilization"`
+	KedaMinReplicas              int                           `yaml:"kedaMinReplicas"`
+	KedaMaxReplicas              int                           `yaml:"kedaMaxReplicas"`
 }
 
 type VirtualServiceRoute struct {
@@ -139,16 +138,14 @@ func (c *Config) ApplyDefaults() {
 	if c.KedaCronEnd == "" {
 		c.KedaCronEnd = defaultKedaCronEnd
 	}
-	if c.KedaDesiredReplicas == "" {
+	if c.KedaDesiredReplicas == 0 {
 		c.KedaDesiredReplicas = defaultKedaDesiredReplicas
 	}
-	if c.KedaCPUUtilization == "" {
+	if c.KedaCPUUtilization == 0 {
 		c.KedaCPUUtilization = defaultKedaCPUUtilization
 	}
-	if c.KedaMinReplicas == "" {
-		c.KedaMinReplicas = defaultKedaMinReplicas
-	}
-	if c.KedaMaxReplicas == "" {
+	// KedaMinReplicas has a default of 0, so no zero-value substitution is needed.
+	if c.KedaMaxReplicas == 0 {
 		c.KedaMaxReplicas = defaultKedaMaxReplicas
 	}
 }
@@ -189,27 +186,23 @@ func (c *Config) validateKedaParams() error {
 		return nil
 	}
 
-	minR, err := strconv.ParseInt(c.KedaMinReplicas, 10, 64)
-	if err != nil || minR < 0 {
-		return fmt.Errorf("kedaMinReplicas must be a non-negative integer: %q", c.KedaMinReplicas)
+	if c.KedaMinReplicas < 0 {
+		return fmt.Errorf("kedaMinReplicas must be a non-negative integer: %d", c.KedaMinReplicas)
 	}
-	maxR, err := strconv.ParseInt(c.KedaMaxReplicas, 10, 64)
-	if err != nil || maxR < 1 {
-		return fmt.Errorf("kedaMaxReplicas must be a positive integer: %q", c.KedaMaxReplicas)
+	if c.KedaMaxReplicas < 1 {
+		return fmt.Errorf("kedaMaxReplicas must be a positive integer: %d", c.KedaMaxReplicas)
 	}
-	desiredR, err := strconv.ParseInt(c.KedaDesiredReplicas, 10, 64)
-	if err != nil || desiredR < 1 {
-		return fmt.Errorf("kedaDesiredReplicas must be a positive integer: %q", c.KedaDesiredReplicas)
+	if c.KedaDesiredReplicas < 1 {
+		return fmt.Errorf("kedaDesiredReplicas must be a positive integer: %d", c.KedaDesiredReplicas)
 	}
-	cpu, err := strconv.ParseInt(c.KedaCPUUtilization, 10, 64)
-	if err != nil || cpu < 1 || cpu > 100 {
-		return fmt.Errorf("kedaCpuUtilization must be in [1, 100]: %q", c.KedaCPUUtilization)
+	if c.KedaCPUUtilization < 1 || c.KedaCPUUtilization > 100 {
+		return fmt.Errorf("kedaCpuUtilization must be in [1, 100]: %d", c.KedaCPUUtilization)
 	}
-	if minR > maxR {
-		return fmt.Errorf("kedaMinReplicas (%d) must be <= kedaMaxReplicas (%d)", minR, maxR)
+	if c.KedaMinReplicas > c.KedaMaxReplicas {
+		return fmt.Errorf("kedaMinReplicas (%d) must be <= kedaMaxReplicas (%d)", c.KedaMinReplicas, c.KedaMaxReplicas)
 	}
-	if desiredR > maxR {
-		return fmt.Errorf("kedaDesiredReplicas (%d) must be <= kedaMaxReplicas (%d)", desiredR, maxR)
+	if c.KedaDesiredReplicas > c.KedaMaxReplicas {
+		return fmt.Errorf("kedaDesiredReplicas (%d) must be <= kedaMaxReplicas (%d)", c.KedaDesiredReplicas, c.KedaMaxReplicas)
 	}
 
 	return nil

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -21,6 +21,9 @@ const (
 	defaultKedaCronStart       = "0 9 * * 1-5"
 	defaultKedaCronEnd         = "0 21 * * 1-5"
 	defaultKedaDesiredReplicas = "1"
+	defaultKedaCPUUtilization  = "50"
+	defaultKedaMinReplicas     = "0"
+	defaultKedaMaxReplicas     = "1"
 	maxDelayPercentage         = 100.0
 )
 
@@ -62,6 +65,9 @@ type Config struct {
 	KedaCronStart                string                        `yaml:"kedaCronStart"`
 	KedaCronEnd                  string                        `yaml:"kedaCronEnd"`
 	KedaDesiredReplicas          string                        `yaml:"kedaDesiredReplicas"`
+	KedaCPUUtilization           string                        `yaml:"kedaCpuUtilization"`
+	KedaMinReplicas              string                        `yaml:"kedaMinReplicas"`
+	KedaMaxReplicas              string                        `yaml:"kedaMaxReplicas"`
 }
 
 type VirtualServiceRoute struct {
@@ -134,6 +140,15 @@ func (c *Config) ApplyDefaults() {
 	}
 	if c.KedaDesiredReplicas == "" {
 		c.KedaDesiredReplicas = defaultKedaDesiredReplicas
+	}
+	if c.KedaCPUUtilization == "" {
+		c.KedaCPUUtilization = defaultKedaCPUUtilization
+	}
+	if c.KedaMinReplicas == "" {
+		c.KedaMinReplicas = defaultKedaMinReplicas
+	}
+	if c.KedaMaxReplicas == "" {
+		c.KedaMaxReplicas = defaultKedaMaxReplicas
 	}
 }
 

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -176,7 +177,42 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid dockerBuildPlatform: %s (must be linux/amd64 or linux/arm64)", c.DockerBuildPlatform)
 	}
 
+	if err := c.validateKedaParams(); err != nil {
+		return err
+	}
+
 	return c.validateVirtualServiceRoutes()
+}
+
+func (c *Config) validateKedaParams() error {
+	if !c.KedaMode {
+		return nil
+	}
+
+	minR, err := strconv.ParseInt(c.KedaMinReplicas, 10, 64)
+	if err != nil || minR < 0 {
+		return fmt.Errorf("kedaMinReplicas must be a non-negative integer: %q", c.KedaMinReplicas)
+	}
+	maxR, err := strconv.ParseInt(c.KedaMaxReplicas, 10, 64)
+	if err != nil || maxR < 1 {
+		return fmt.Errorf("kedaMaxReplicas must be a positive integer: %q", c.KedaMaxReplicas)
+	}
+	desiredR, err := strconv.ParseInt(c.KedaDesiredReplicas, 10, 64)
+	if err != nil || desiredR < 1 {
+		return fmt.Errorf("kedaDesiredReplicas must be a positive integer: %q", c.KedaDesiredReplicas)
+	}
+	cpu, err := strconv.ParseInt(c.KedaCPUUtilization, 10, 64)
+	if err != nil || cpu < 1 || cpu > 100 {
+		return fmt.Errorf("kedaCpuUtilization must be in [1, 100]: %q", c.KedaCPUUtilization)
+	}
+	if minR > maxR {
+		return fmt.Errorf("kedaMinReplicas (%d) must be <= kedaMaxReplicas (%d)", minR, maxR)
+	}
+	if desiredR > maxR {
+		return fmt.Errorf("kedaDesiredReplicas (%d) must be <= kedaMaxReplicas (%d)", desiredR, maxR)
+	}
+
+	return nil
 }
 
 func (c *Config) validateVirtualServiceRoutes() error {

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -17,6 +17,10 @@ const (
 	defaultIstioProxyCPU       = "500m"
 	defaultIstioProxyMemory    = "512Mi"
 	defaultDockerBuildPlatform = "linux/amd64"
+	defaultKedaCronTimezone    = "Asia/Tokyo"
+	defaultKedaCronStart       = "0 9 * * 1-5"
+	defaultKedaCronEnd         = "0 21 * * 1-5"
+	defaultKedaDesiredReplicas = "1"
 	maxDelayPercentage         = 100.0
 )
 
@@ -53,6 +57,11 @@ type Config struct {
 	EcrTags                      []ECRTag                      `yaml:"ecrTags"`
 	VirtualServiceRoutes         []VirtualServiceRoute         `yaml:"virtualServiceRoutes"`
 	DockerBuildPlatform          string                        `yaml:"dockerBuildPlatform"`
+	KedaMode                     bool                          `yaml:"kedaMode"`
+	KedaCronTimezone             string                        `yaml:"kedaCronTimezone"`
+	KedaCronStart                string                        `yaml:"kedaCronStart"`
+	KedaCronEnd                  string                        `yaml:"kedaCronEnd"`
+	KedaDesiredReplicas          string                        `yaml:"kedaDesiredReplicas"`
 }
 
 type VirtualServiceRoute struct {
@@ -113,6 +122,18 @@ func (c *Config) ApplyDefaults() {
 	}
 	if c.DockerBuildPlatform == "" {
 		c.DockerBuildPlatform = defaultDockerBuildPlatform
+	}
+	if c.KedaCronTimezone == "" {
+		c.KedaCronTimezone = defaultKedaCronTimezone
+	}
+	if c.KedaCronStart == "" {
+		c.KedaCronStart = defaultKedaCronStart
+	}
+	if c.KedaCronEnd == "" {
+		c.KedaCronEnd = defaultKedaCronEnd
+	}
+	if c.KedaDesiredReplicas == "" {
+		c.KedaDesiredReplicas = defaultKedaDesiredReplicas
 	}
 }
 

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -21,7 +21,6 @@ const (
 	defaultKedaCronStart       = "0 9 * * 1-5"
 	defaultKedaCronEnd         = "0 21 * * 1-5"
 	defaultKedaDesiredReplicas = 1
-	defaultKedaCPUUtilization  = 50
 	defaultKedaMinReplicas     = 0
 	defaultKedaMaxReplicas     = 1
 	maxDelayPercentage         = 100.0
@@ -65,7 +64,6 @@ type Config struct {
 	KedaCronStart                string                        `yaml:"kedaCronStart"`
 	KedaCronEnd                  string                        `yaml:"kedaCronEnd"`
 	KedaDesiredReplicas          int                           `yaml:"kedaDesiredReplicas"`
-	KedaCPUUtilization           int                           `yaml:"kedaCpuUtilization"`
 	KedaMinReplicas              int                           `yaml:"kedaMinReplicas"`
 	KedaMaxReplicas              int                           `yaml:"kedaMaxReplicas"`
 }
@@ -141,9 +139,6 @@ func (c *Config) ApplyDefaults() {
 	if c.KedaDesiredReplicas == 0 {
 		c.KedaDesiredReplicas = defaultKedaDesiredReplicas
 	}
-	if c.KedaCPUUtilization == 0 {
-		c.KedaCPUUtilization = defaultKedaCPUUtilization
-	}
 	// KedaMinReplicas has a default of 0, so no zero-value substitution is needed.
 	if c.KedaMaxReplicas == 0 {
 		c.KedaMaxReplicas = defaultKedaMaxReplicas
@@ -194,9 +189,6 @@ func (c *Config) validateKedaParams() error {
 	}
 	if c.KedaDesiredReplicas < 1 {
 		return fmt.Errorf("kedaDesiredReplicas must be a positive integer: %d", c.KedaDesiredReplicas)
-	}
-	if c.KedaCPUUtilization < 1 || c.KedaCPUUtilization > 100 {
-		return fmt.Errorf("kedaCpuUtilization must be in [1, 100]: %d", c.KedaCPUUtilization)
 	}
 	if c.KedaMinReplicas > c.KedaMaxReplicas {
 		return fmt.Errorf("kedaMinReplicas (%d) must be <= kedaMaxReplicas (%d)", c.KedaMinReplicas, c.KedaMaxReplicas)

--- a/app/params/params_test.go
+++ b/app/params/params_test.go
@@ -258,48 +258,43 @@ func TestValidate_KedaErrors(t *testing.T) {
 		errSubstr string
 	}{
 		{
-			name:      "non-numeric kedaMinReplicas",
-			mutate:    func(c *params.Config) { c.KedaMinReplicas = "abc" },
-			errSubstr: "kedaMinReplicas must be a non-negative integer",
-		},
-		{
 			name:      "negative kedaMinReplicas",
-			mutate:    func(c *params.Config) { c.KedaMinReplicas = "-1" },
+			mutate:    func(c *params.Config) { c.KedaMinReplicas = -1 },
 			errSubstr: "kedaMinReplicas must be a non-negative integer",
 		},
 		{
-			name:      "zero kedaMaxReplicas",
-			mutate:    func(c *params.Config) { c.KedaMaxReplicas = "0" },
+			name:      "negative kedaMaxReplicas",
+			mutate:    func(c *params.Config) { c.KedaMaxReplicas = -1 },
 			errSubstr: "kedaMaxReplicas must be a positive integer",
 		},
 		{
-			name:      "zero kedaDesiredReplicas",
-			mutate:    func(c *params.Config) { c.KedaDesiredReplicas = "0" },
+			name:      "negative kedaDesiredReplicas",
+			mutate:    func(c *params.Config) { c.KedaDesiredReplicas = -1 },
 			errSubstr: "kedaDesiredReplicas must be a positive integer",
 		},
 		{
-			name:      "kedaCpuUtilization below range",
-			mutate:    func(c *params.Config) { c.KedaCPUUtilization = "0" },
+			name:      "negative kedaCpuUtilization",
+			mutate:    func(c *params.Config) { c.KedaCPUUtilization = -1 },
 			errSubstr: "kedaCpuUtilization must be in [1, 100]",
 		},
 		{
 			name:      "kedaCpuUtilization above 100",
-			mutate:    func(c *params.Config) { c.KedaCPUUtilization = "101" },
+			mutate:    func(c *params.Config) { c.KedaCPUUtilization = 101 },
 			errSubstr: "kedaCpuUtilization must be in [1, 100]",
 		},
 		{
 			name: "kedaMinReplicas exceeds kedaMaxReplicas",
 			mutate: func(c *params.Config) {
-				c.KedaMinReplicas = "5"
-				c.KedaMaxReplicas = "1"
+				c.KedaMinReplicas = 5
+				c.KedaMaxReplicas = 1
 			},
 			errSubstr: "kedaMinReplicas (5) must be <= kedaMaxReplicas (1)",
 		},
 		{
 			name: "kedaDesiredReplicas exceeds kedaMaxReplicas",
 			mutate: func(c *params.Config) {
-				c.KedaDesiredReplicas = "3"
-				c.KedaMaxReplicas = "1"
+				c.KedaDesiredReplicas = 3
+				c.KedaMaxReplicas = 1
 			},
 			errSubstr: "kedaDesiredReplicas (3) must be <= kedaMaxReplicas (1)",
 		},

--- a/app/params/params_test.go
+++ b/app/params/params_test.go
@@ -273,16 +273,6 @@ func TestValidate_KedaErrors(t *testing.T) {
 			errSubstr: "kedaDesiredReplicas must be a positive integer",
 		},
 		{
-			name:      "negative kedaCpuUtilization",
-			mutate:    func(c *params.Config) { c.KedaCPUUtilization = -1 },
-			errSubstr: "kedaCpuUtilization must be in [1, 100]",
-		},
-		{
-			name:      "kedaCpuUtilization above 100",
-			mutate:    func(c *params.Config) { c.KedaCPUUtilization = 101 },
-			errSubstr: "kedaCpuUtilization must be in [1, 100]",
-		},
-		{
 			name: "kedaMinReplicas exceeds kedaMaxReplicas",
 			mutate: func(c *params.Config) {
 				c.KedaMinReplicas = 5

--- a/app/params/params_test.go
+++ b/app/params/params_test.go
@@ -244,3 +244,75 @@ func validConfig() *params.Config {
 		PrismMockSuffix:       "-mock",
 	}
 }
+
+func TestValidate_KedaHappyPath(t *testing.T) {
+	cfg := validConfig()
+	cfg.KedaMode = true
+	require.NoError(t, cfg.Validate())
+}
+
+func TestValidate_KedaErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*params.Config)
+		errSubstr string
+	}{
+		{
+			name:      "non-numeric kedaMinReplicas",
+			mutate:    func(c *params.Config) { c.KedaMinReplicas = "abc" },
+			errSubstr: "kedaMinReplicas must be a non-negative integer",
+		},
+		{
+			name:      "negative kedaMinReplicas",
+			mutate:    func(c *params.Config) { c.KedaMinReplicas = "-1" },
+			errSubstr: "kedaMinReplicas must be a non-negative integer",
+		},
+		{
+			name:      "zero kedaMaxReplicas",
+			mutate:    func(c *params.Config) { c.KedaMaxReplicas = "0" },
+			errSubstr: "kedaMaxReplicas must be a positive integer",
+		},
+		{
+			name:      "zero kedaDesiredReplicas",
+			mutate:    func(c *params.Config) { c.KedaDesiredReplicas = "0" },
+			errSubstr: "kedaDesiredReplicas must be a positive integer",
+		},
+		{
+			name:      "kedaCpuUtilization below range",
+			mutate:    func(c *params.Config) { c.KedaCPUUtilization = "0" },
+			errSubstr: "kedaCpuUtilization must be in [1, 100]",
+		},
+		{
+			name:      "kedaCpuUtilization above 100",
+			mutate:    func(c *params.Config) { c.KedaCPUUtilization = "101" },
+			errSubstr: "kedaCpuUtilization must be in [1, 100]",
+		},
+		{
+			name: "kedaMinReplicas exceeds kedaMaxReplicas",
+			mutate: func(c *params.Config) {
+				c.KedaMinReplicas = "5"
+				c.KedaMaxReplicas = "1"
+			},
+			errSubstr: "kedaMinReplicas (5) must be <= kedaMaxReplicas (1)",
+		},
+		{
+			name: "kedaDesiredReplicas exceeds kedaMaxReplicas",
+			mutate: func(c *params.Config) {
+				c.KedaDesiredReplicas = "3"
+				c.KedaMaxReplicas = "1"
+			},
+			errSubstr: "kedaDesiredReplicas (3) must be <= kedaMaxReplicas (1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.KedaMode = true
+			tt.mutate(cfg)
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errSubstr)
+		})
+	}
+}

--- a/app/run.go
+++ b/app/run.go
@@ -106,8 +106,10 @@ func (a *App) Delete(ctx context.Context) error {
 		return fmt.Errorf("k8s resource deletion failed: %w", err)
 	}
 
-	if err := registry.DeleteECR(ctx, a.AWSConfig, a.ResourceName); err != nil {
-		return fmt.Errorf("ECR deletion failed: %w", err)
+	if !a.IsTest {
+		if err := registry.DeleteECR(ctx, a.AWSConfig, a.ResourceName); err != nil {
+			return fmt.Errorf("ECR deletion failed: %w", err)
+		}
 	}
 
 	slog.Info("All resources for prism mock are deleted successfully")

--- a/app/run.go
+++ b/app/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gold-kou/prism-in-k8s/app/istio"
 	"github.com/gold-kou/prism-in-k8s/app/k8s"
+	"github.com/gold-kou/prism-in-k8s/app/keda"
 	"github.com/gold-kou/prism-in-k8s/app/params"
 	"github.com/gold-kou/prism-in-k8s/app/registry"
 	restclient "k8s.io/client-go/rest"
@@ -78,6 +79,12 @@ func (a *App) Create(ctx context.Context) error {
 		}
 	}
 
+	if a.Config.KedaMode {
+		if err := keda.CreateKedaResources(ctx, a.Config, a.KubeConfig, a.NamespaceName, a.ResourceName); err != nil {
+			return fmt.Errorf("KEDA resource creation failed: %w", err)
+		}
+	}
+
 	slog.Info("All resources for prism mock are created successfully")
 	return nil
 }
@@ -86,6 +93,12 @@ func (a *App) Delete(ctx context.Context) error {
 	if a.Config.IstioMode {
 		if err := istio.DeleteIstioResources(ctx, a.KubeConfig, a.NamespaceName, a.ResourceName); err != nil {
 			return fmt.Errorf("istio resource deletion failed: %w", err)
+		}
+	}
+
+	if a.Config.KedaMode {
+		if err := keda.DeleteKedaResources(ctx, a.KubeConfig, a.NamespaceName, a.ResourceName); err != nil {
+			return fmt.Errorf("KEDA resource deletion failed: %w", err)
 		}
 	}
 

--- a/config/params.yaml
+++ b/config/params.yaml
@@ -8,3 +8,10 @@ prismMockSuffix: "-prism-mock"
 #     method: "GET"
 #     delayNanos: 100000000  # 100ms
 #     delayPercentage: 100.0
+
+# KEDA ScaledObject with Cron trigger (optional, requires KEDA installed in cluster)
+# kedaMode: true
+# kedaCronTimezone: "Asia/Tokyo"       # default: Asia/Tokyo
+# kedaCronStart: "0 9 * * 1-5"         # default: weekdays 09:00
+# kedaCronEnd: "0 21 * * 1-5"          # default: weekdays 21:00
+# kedaDesiredReplicas: "1"             # default: 1

--- a/config/params.yaml
+++ b/config/params.yaml
@@ -9,12 +9,11 @@ prismMockSuffix: "-prism-mock"
 #     delayNanos: 100000000  # 100ms
 #     delayPercentage: 100.0
 
-# KEDA ScaledObject with CPU + Cron triggers (optional, requires KEDA installed in cluster)
+# KEDA ScaledObject with Cron trigger (optional, requires KEDA installed in cluster)
 # kedaMode: true
 # kedaCronTimezone: "Asia/Tokyo"       # default: Asia/Tokyo
 # kedaCronStart: "0 9 * * 1-5"         # default: weekdays 09:00
 # kedaCronEnd: "0 21 * * 1-5"          # default: weekdays 21:00
 # kedaDesiredReplicas: 1               # default: 1
-# kedaCpuUtilization: 50               # default: 50 (Utilization %)
 # kedaMinReplicas: 0                   # default: 0
 # kedaMaxReplicas: 1                   # default: 1

--- a/config/params.yaml
+++ b/config/params.yaml
@@ -9,9 +9,12 @@ prismMockSuffix: "-prism-mock"
 #     delayNanos: 100000000  # 100ms
 #     delayPercentage: 100.0
 
-# KEDA ScaledObject with Cron trigger (optional, requires KEDA installed in cluster)
+# KEDA ScaledObject with CPU + Cron triggers (optional, requires KEDA installed in cluster)
 # kedaMode: true
 # kedaCronTimezone: "Asia/Tokyo"       # default: Asia/Tokyo
 # kedaCronStart: "0 9 * * 1-5"         # default: weekdays 09:00
 # kedaCronEnd: "0 21 * * 1-5"          # default: weekdays 21:00
 # kedaDesiredReplicas: "1"             # default: 1
+# kedaCpuUtilization: "50"             # default: 50 (Utilization %)
+# kedaMinReplicas: "0"                 # default: 0
+# kedaMaxReplicas: "1"                 # default: 1

--- a/config/params.yaml
+++ b/config/params.yaml
@@ -14,7 +14,7 @@ prismMockSuffix: "-prism-mock"
 # kedaCronTimezone: "Asia/Tokyo"       # default: Asia/Tokyo
 # kedaCronStart: "0 9 * * 1-5"         # default: weekdays 09:00
 # kedaCronEnd: "0 21 * * 1-5"          # default: weekdays 21:00
-# kedaDesiredReplicas: "1"             # default: 1
-# kedaCpuUtilization: "50"             # default: 50 (Utilization %)
-# kedaMinReplicas: "0"                 # default: 0
-# kedaMaxReplicas: "1"                 # default: 1
+# kedaDesiredReplicas: 1               # default: 1
+# kedaCpuUtilization: 50               # default: 50 (Utilization %)
+# kedaMinReplicas: 0                   # default: 0
+# kedaMaxReplicas: 1                   # default: 1


### PR DESCRIPTION
Closes #34

## Summary

Add optional KEDA ScaledObject with a Cron trigger to scale Pods between configurable min/max replicas based on a scheduled window. Opt-in via `kedaMode: true`; no behavior change when disabled.

## How to use

Enable in `config/params.yaml`:

```yaml
kedaMode: true
kedaCronTimezone: "Asia/Tokyo"
kedaCronStart: "0 9 * * 1-5"
kedaCronEnd: "0 21 * * 1-5"
kedaDesiredReplicas: 1
kedaMinReplicas: 0
kedaMaxReplicas: 1
```

Requires KEDA installed in the target cluster.

## Test plan

- [x] Unit tests for `BuildScaledObject` (Cron trigger, custom min / max)
- [x] Unit tests for `Validate()` KEDA params (range, min<=max, desired<=max)
- [x] `go build ./...` / `go test ./...` / `golangci-lint run ./...` pass
- [x] Manual verification on a KEDA v2.18.3 cluster: cron triggers Pod 0→1 at start, 1→0 ~5 min after end (default `cooldownPeriod: 300s`)
```bash
Events:
  Type    Reason                      Age                 From           Message
  ----    ------                      ----                ----           -------
  Normal  KEDAScalersStarted          30m                 keda-operator  Started scalers watch
  Normal  ScaledObjectReady           30m (x2 over 30m)   keda-operator  ScaledObject is ready for scaling
  Normal  KEDAScalersStarted          12m (x3 over 30m)   keda-operator  Scaler cron is built
  Normal  KEDAScaleTargetActivated    11m (x2 over 26m)   keda-operator  Scaled apps/v1.Deployment keda-pr56-prism-mock/keda-pr56-prism-mock from 0 to 1, triggered by cronScaler
  Normal  KEDAScaleTargetDeactivated  101s (x3 over 30m)  keda-operator  Deactivated apps/v1.Deployment keda-pr56-prism-mock/keda-pr56-prism-mock from 1 to 0
```

```bash
// start trigger
$ kubectl get pod -n keda-pr56-prism-mock
NAME                                        READY   STATUS    RESTARTS   AGE
pod/keda-pr56-prism-mock-56498cfb96-jfqfg   1/1     Running   0          110s

// stop trigger
$ kubectl get pod,scaledobject,hpa -n keda-pr56-prism-mock
// no resource
```