### PR TITLE
Remove unnecessary sentinel error wrapping

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - noinlineerr # prefer inline error handling
     - wsl_v5 # do not enforce newline rules (v2 equivalent of wsl)
     - godoclint # do not enforce godoc format
+    - err113 # prefer inline error messages over sentinel-then-wrap when errors are not programmatically checked
   settings:
     forbidigo:
       forbid:

--- a/app/istio/istio.go
+++ b/app/istio/istio.go
@@ -2,7 +2,6 @@ package istio
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 
@@ -20,17 +19,11 @@ const (
 	defaultDelayPercentage = 100.0     // 100%
 )
 
-var (
-	errFailedToCreateIstioClient    = errors.New("failed to create Istio client")
-	errFailedToCreateVirtualService = errors.New("failed to create VirtualService")
-	errFailedToDeleteVirtualService = errors.New("failed to delete VirtualService")
-)
-
 func CreateIstioResources(ctx context.Context, kubeconfig *restclient.Config, namespaceName, resourceName string) error {
 	// Istio clientset
 	istioClientSet, err := versioned.NewForConfig(kubeconfig)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToCreateIstioClient, err)
+		return fmt.Errorf("failed to create Istio client: %w", err)
 	}
 
 	// VirtualService
@@ -93,7 +86,7 @@ func CreateIstioResources(ctx context.Context, kubeconfig *restclient.Config, na
 	_, err = istioClientSet.NetworkingV1alpha3().VirtualServices(namespaceName).Create(ctx, virtualService, metav1.CreateOptions{})
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("%w: %w", errFailedToCreateVirtualService, err)
+			return fmt.Errorf("failed to create VirtualService: %w", err)
 		}
 		log.Println("[WARN] The VirtualService already exists")
 	} else {
@@ -106,14 +99,14 @@ func DeleteIstioResources(ctx context.Context, kubeconfig *restclient.Config, na
 	// Istio clientset
 	istioClientSet, err := versioned.NewForConfig(kubeconfig)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToCreateIstioClient, err)
+		return fmt.Errorf("failed to create Istio client: %w", err)
 	}
 	log.Println("[INFO] Clientset of istio set up successfully")
 
 	err = istioClientSet.NetworkingV1alpha3().VirtualServices(namespaceName).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("%w: %w", errFailedToDeleteVirtualService, err)
+			return fmt.Errorf("failed to delete VirtualService: %w", err)
 		}
 		log.Println("[WARN] The VirtualService is not found")
 	} else {

--- a/app/k8s/k8s.go
+++ b/app/k8s/k8s.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -27,40 +26,25 @@ const (
 	servicePort     = 80
 )
 
-var (
-	errFailedToCreateClientSet  = errors.New("failed to create clientset")
-	errFailedToCreateNameSpace  = errors.New("failed to create namespace")
-	errFailedToCreateDeployment = errors.New("failed to create deployment")
-	errFailedToCreateService    = errors.New("failed to create service")
-	errFailedToDeleteNameSpace  = errors.New("failed to delete namespace")
-	errFailedToDeleteDeployment = errors.New("failed to delete deployment")
-	errFailedToDeleteService    = errors.New("failed to delete service")
-	errFailedToListPods         = errors.New("failed to list pods")
-	errFailedToGetLatestVersion = errors.New("failed to get latest version")
-	errNoValidVersionFound      = errors.New("no valid version found")
-	errInvalidVersionFormat     = errors.New("invalid version format")
-	errInvalidNumberInVersion   = errors.New("invalid number in version")
-)
-
 func CreateK8sResources(ctx context.Context, awsAccountID string, awsConfig aws.Config, kubeconfig *restclient.Config, namespaceName, resourceName string, istioMode, isTest bool) error {
 	k8sClientSet, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToCreateClientSet, err)
+		return fmt.Errorf("failed to create clientset: %w", err)
 	}
 
 	err = createNamespace(ctx, k8sClientSet, namespaceName, istioMode)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToCreateNameSpace, err)
+		return fmt.Errorf("failed to create namespace: %w", err)
 	}
 
 	err = createDeployment(ctx, awsAccountID, awsConfig, k8sClientSet, namespaceName, resourceName, istioMode, isTest)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToCreateDeployment, err)
+		return fmt.Errorf("failed to create deployment: %w", err)
 	}
 
 	err = createService(ctx, k8sClientSet, namespaceName, resourceName)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToCreateService, err)
+		return fmt.Errorf("failed to create service: %w", err)
 	}
 
 	return nil
@@ -81,7 +65,7 @@ func createNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, na
 			LabelSelector: "app=istiod",
 		})
 		if err != nil {
-			return fmt.Errorf("%w: %w", errFailedToListPods, err)
+			return fmt.Errorf("failed to list pods: %w", err)
 		}
 		hyphenedVersions := []string{}
 		for _, item := range podList.Items {
@@ -89,7 +73,7 @@ func createNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, na
 		}
 		latestVersion, err := getLatestVersion(hyphenedVersions)
 		if err != nil {
-			return fmt.Errorf("%w: %w", errFailedToGetLatestVersion, err)
+			return fmt.Errorf("failed to get latest version: %w", err)
 		}
 		namespace.ObjectMeta.Labels["istio.io/rev"] = latestVersion
 	}
@@ -97,7 +81,7 @@ func createNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, na
 	_, err := k8sClientSet.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("%w: %w", errFailedToCreateNameSpace, err)
+			return fmt.Errorf("failed to create namespace: %w", err)
 		}
 		log.Println("[WARN] The namespace already exists")
 	} else {
@@ -174,7 +158,7 @@ func createDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Co
 	_, err := k8sClientSet.AppsV1().Deployments(namespaceName).Create(ctx, deployment, metav1.CreateOptions{})
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("%w: %w", errFailedToCreateDeployment, err)
+			return fmt.Errorf("failed to create deployment: %w", err)
 		}
 		log.Println("[WARN] The deployment already exists")
 	} else {
@@ -257,7 +241,7 @@ func createService(ctx context.Context, k8sClientSet *kubernetes.Clientset, name
 	_, err := k8sClientSet.CoreV1().Services(namespaceName).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("%w: %w", errFailedToCreateService, err)
+			return fmt.Errorf("failed to create service: %w", err)
 		}
 		log.Println("[WARN] The service already exists")
 	} else {
@@ -269,23 +253,23 @@ func createService(ctx context.Context, k8sClientSet *kubernetes.Clientset, name
 func DeleteK8sResources(ctx context.Context, kubeconfig *restclient.Config, namespaceName, resourceName string) error {
 	k8sClientSet, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToCreateClientSet, err)
+		return fmt.Errorf("failed to create clientset: %w", err)
 	}
 	log.Println("[INFO] Clientset of k8s set up successfully")
 
 	err = deleteService(ctx, k8sClientSet, namespaceName, resourceName)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToDeleteService, err)
+		return fmt.Errorf("failed to delete service: %w", err)
 	}
 
 	err = deleteDeployment(ctx, k8sClientSet, namespaceName, resourceName)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToDeleteDeployment, err)
+		return fmt.Errorf("failed to delete deployment: %w", err)
 	}
 
 	err = deleteNamespace(ctx, k8sClientSet, namespaceName)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToDeleteNameSpace, err)
+		return fmt.Errorf("failed to delete namespace: %w", err)
 	}
 
 	return nil
@@ -295,7 +279,7 @@ func deleteService(ctx context.Context, k8sClientSet *kubernetes.Clientset, name
 	err := k8sClientSet.CoreV1().Services(namespaceName).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("%w: %w", errFailedToDeleteService, err)
+			return fmt.Errorf("failed to delete service: %w", err)
 		}
 		log.Println("[WARN] The service is not found")
 	} else {
@@ -308,7 +292,7 @@ func deleteDeployment(ctx context.Context, k8sClientSet *kubernetes.Clientset, n
 	err := k8sClientSet.AppsV1().Deployments(namespaceName).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("%w: %w", errFailedToDeleteDeployment, err)
+			return fmt.Errorf("failed to delete deployment: %w", err)
 		}
 		log.Println("[WARN] The Deployment is not found")
 	} else {
@@ -321,7 +305,7 @@ func deleteNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, na
 	err := k8sClientSet.CoreV1().Namespaces().Delete(ctx, namespaceName, metav1.DeleteOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("%w: %w", errFailedToDeleteNameSpace, err)
+			return fmt.Errorf("failed to delete namespace: %w", err)
 		}
 		log.Println("[WARN] The Namespace is not found")
 	} else {
@@ -336,14 +320,14 @@ func parseVersion(version string) ([]int, error) {
 	// convert "x-y-z" to [x, y, z]
 	parts := strings.Split(version, "-")
 	if len(parts) != versions {
-		return nil, fmt.Errorf("%w: %s", errInvalidVersionFormat, version)
+		return nil, fmt.Errorf("invalid version format: %s", version)
 	}
 
 	intParts := make([]int, len(parts))
 	for i, part := range parts {
 		num, err := strconv.Atoi(part)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %s", errInvalidNumberInVersion, part)
+			return nil, fmt.Errorf("invalid number in version: %s", part)
 		}
 		intParts[i] = num
 	}
@@ -399,5 +383,5 @@ func getLatestVersion(versions []string) (string, error) {
 		return nonVersionRevision, nil
 	}
 
-	return "", fmt.Errorf("%w: %v", errNoValidVersionFound, versions)
+	return "", fmt.Errorf("no valid version found: %v", versions)
 }

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -1,7 +1,6 @@
 package params
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -18,14 +17,6 @@ const (
 	defaultIstioMode        = false
 	defaultIstioProxyCPU    = "500m"
 	defaultIstioProxyMemory = "512Mi"
-)
-
-var (
-	errEmptyParameter                = errors.New("empty parameter found")
-	errUnsupportedParameterType      = errors.New("unsupported parameter type")
-	errFailedToOpenConfigFile        = errors.New("failed to open config file")
-	errFailedToDecodeConfigFile      = errors.New("failed to decode config file")
-	errInvalidNodeSelectorOperator   = errors.New("invalid node selector operator")
 )
 
 var validNodeSelectorOperators = map[string]bool{
@@ -133,14 +124,14 @@ func init() {
 func LoadConfig(filename string) (*Config, error) {
 	file, err := os.Open(filename)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errFailedToOpenConfigFile, err)
+		return nil, fmt.Errorf("failed to open config file: %w", err)
 	}
 	defer file.Close()
 
 	var config Config
 	decoder := yaml.NewDecoder(file)
 	if err := decoder.Decode(&config); err != nil {
-		return nil, fmt.Errorf("%w: %w", errFailedToDecodeConfigFile, err)
+		return nil, fmt.Errorf("failed to decode config file: %w", err)
 	}
 
 	return &config, nil
@@ -163,24 +154,24 @@ func ValidateParams() error {
 		switch v := value.(type) {
 		case string:
 			if v == "" {
-				return fmt.Errorf("%w: %s", errEmptyParameter, name)
+				return fmt.Errorf("empty parameter found: %s", name)
 			}
 		case int:
 			if v == 0 {
-				return fmt.Errorf("%w: %s", errEmptyParameter, name)
+				return fmt.Errorf("empty parameter found: %s", name)
 			}
 		case time.Duration:
 			if v == 0*time.Millisecond {
-				return fmt.Errorf("%w: %s", errEmptyParameter, name)
+				return fmt.Errorf("empty parameter found: %s", name)
 			}
 		default:
-			return fmt.Errorf("%w: %s", errUnsupportedParameterType, name)
+			return fmt.Errorf("unsupported parameter type: %s", name)
 		}
 	}
 
 	for _, expr := range NodeAffinityMatchExpressions {
 		if !validNodeSelectorOperators[expr.Operator] {
-			return fmt.Errorf("%w: %s", errInvalidNodeSelectorOperator, expr.Operator)
+			return fmt.Errorf("invalid node selector operator: %s", expr.Operator)
 		}
 	}
 

--- a/app/registry/ecr.go
+++ b/app/registry/ecr.go
@@ -15,21 +15,12 @@ import (
 	"github.com/gold-kou/prism-in-k8s/app/params"
 )
 
-var (
-	errFailedToBuildDockerImage = errors.New("failed to build docker image")
-	errFailedToCreateECR        = errors.New("failed to create ECR repository")
-	errFailedToTagImage         = errors.New("failed to tag image")
-	errFailedToLoginECR         = errors.New("failed to log in ECR")
-	errFailedToPushImage        = errors.New("failed to push image to ECR")
-	errFailedToDeleteECR        = errors.New("failed to delete ECR repository")
-)
-
 func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, resourceName string) error {
 	// build Docker image
 	imageTag := params.MicroserviceName + ":v1"
 	cmd := exec.CommandContext(ctx, "docker", "build", "--platform", "linux/amd64", "-f", "Dockerfile.prism", "-t", imageTag, ".")
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%w: %w", errFailedToBuildDockerImage, err)
+		return fmt.Errorf("failed to build docker image: %w", err)
 	}
 	log.Println("[INFO] Docker image is built successfully")
 
@@ -55,7 +46,7 @@ func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, re
 	if err != nil {
 		var ecrExistsException *types.RepositoryAlreadyExistsException
 		if !errors.As(err, &ecrExistsException) {
-			return fmt.Errorf("%w: %w", errFailedToCreateECR, err)
+			return fmt.Errorf("failed to create ECR repository: %w", err)
 		}
 		log.Println("[WARN] The ECR already exists")
 	} else {
@@ -66,21 +57,21 @@ func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, re
 	ecrImageTag := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:latest", awsAccountID, awsConfig.Region, repositoryName)
 	cmdTag := exec.CommandContext(ctx, "docker", "tag", imageTag, ecrImageTag)
 	if err := cmdTag.Run(); err != nil {
-		return fmt.Errorf("%w: %w", errFailedToTagImage, err)
+		return fmt.Errorf("failed to tag image: %w", err)
 	}
 	log.Println("[INFO] Docker image tagged successfully")
 
 	// login to ECR
 	err = loginToECR(ctx, awsConfig, awsAccountID)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToLoginECR, err)
+		return fmt.Errorf("failed to log in ECR: %w", err)
 	}
 	log.Println("[INFO] Logged in ECR successfully")
 
 	// push image to ECR
 	cmdPush := exec.CommandContext(ctx, "docker", "push", ecrImageTag)
 	if err := cmdPush.Run(); err != nil {
-		return fmt.Errorf("%w: %w", errFailedToPushImage, err)
+		return fmt.Errorf("failed to push image to ECR: %w", err)
 	}
 	log.Println("[INFO] Docker image is pushed to ECR successfully")
 	return nil
@@ -94,23 +85,23 @@ func loginToECR(ctx context.Context, awsConfig aws.Config, awsAccountID string) 
 		RegistryIds: []string{awsAccountID},
 	})
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToLoginECR, err)
+		return fmt.Errorf("failed to log in ECR: %w", err)
 	}
 
 	if len(authTokenOutput.AuthorizationData) == 0 {
-		return fmt.Errorf("%w: no authorization data found", errFailedToLoginECR)
+		return errors.New("failed to log in ECR: no authorization data found")
 	}
 
 	authData := authTokenOutput.AuthorizationData[0]
 	decodedToken, err := base64.StdEncoding.DecodeString(*authData.AuthorizationToken)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToLoginECR, err)
+		return fmt.Errorf("failed to log in ECR: %w", err)
 	}
 
 	decodedTokenParts := 2
 	parts := strings.SplitN(string(decodedToken), ":", decodedTokenParts)
 	if len(parts) != decodedTokenParts {
-		return fmt.Errorf("%w: invalid authorization token format", errFailedToLoginECR)
+		return errors.New("failed to log in ECR: invalid authorization token format")
 	}
 
 	username := parts[0]
@@ -121,7 +112,7 @@ func loginToECR(ctx context.Context, awsConfig aws.Config, awsAccountID string) 
 	loginCmd.Stdin = strings.NewReader(password)
 	output, err := loginCmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("%w: %w\n%s", errFailedToLoginECR, err, string(output))
+		return fmt.Errorf("failed to log in ECR: %w\n%s", err, string(output))
 	}
 
 	return nil
@@ -139,7 +130,7 @@ func DeleteECR(ctx context.Context, awsConfig aws.Config, resourceName string) e
 	if err != nil {
 		var ecrNotFoundException *types.RepositoryNotFoundException
 		if !errors.As(err, &ecrNotFoundException) {
-			return fmt.Errorf("%w: %w", errFailedToDeleteECR, err)
+			return fmt.Errorf("failed to delete ECR repository: %w", err)
 		}
 		log.Println("[WARN] The ECR is not found")
 	} else {

--- a/app/run.go
+++ b/app/run.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -16,12 +15,6 @@ import (
 	"github.com/gold-kou/prism-in-k8s/app/registry"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-)
-
-var (
-	errFailedToLoadAWSConfig     = errors.New("failed to load AWS config")
-	errFailedToGetCallerIdentity = errors.New("failed to get caller identity")
-	errFailedToBuildKubeConfig   = errors.New("failed to build Kubeconfig")
 )
 
 var (
@@ -52,14 +45,14 @@ func init() {
 		// AWS config
 		awsConfig, err = config.LoadDefaultConfig(context.Background())
 		if err != nil {
-			panic(fmt.Errorf("%w: %w", errFailedToLoadAWSConfig, err))
+			panic(fmt.Errorf("failed to load AWS config: %w", err))
 		}
 
 		// get AWS account ID
 		stsClient := sts.NewFromConfig(awsConfig)
 		result, err := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
 		if err != nil {
-			panic(fmt.Errorf("%w: %w", errFailedToGetCallerIdentity, err))
+			panic(fmt.Errorf("failed to get caller identity: %w", err))
 		}
 		awsAccountID = *result.Account
 	}
@@ -68,7 +61,7 @@ func init() {
 	kubeconfigPath := clientcmd.NewDefaultPathOptions().GetDefaultFilename()
 	kubeConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
-		panic(fmt.Errorf("%w: %w", errFailedToBuildKubeConfig, err))
+		panic(fmt.Errorf("failed to build Kubeconfig: %w", err))
 	}
 
 	// resource name


### PR DESCRIPTION
## Summary
- Package-private `err*` sentinels were not checked via `errors.Is`/`errors.As` anywhere, so the `fmt.Errorf("%w: %w", errX, err)` pattern was pure boilerplate.
- Remove all such sentinels and replace with inline `fmt.Errorf("failed to X: %w", err)`.
- Disable the `err113` linter globally — dynamic error messages are appropriate when errors are not programmatically inspected.

## Test plan
- [x] `go build ./...`
- [x] `make test-go` (istio/k8s integration tests on kind cluster all pass)
- [x] `make lint` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)