### PR TITLE
Add GoReleaser config and release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # to create GitHub Release
+  packages: write # to push images to ghcr.io
+
+jobs:
+  goreleaser:
+    name: Release via GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ go.work.sum
 
 # env file
 .env
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ go.work.sum
 # env file
 .env
 dist/
+
+# Local build output
+/prism-in-k8s

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,91 @@
+version: 2
+
+project_name: prism-in-k8s
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: prism-in-k8s
+    main: ./main.go
+    binary: prism-in-k8s
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: default
+    formats:
+      - tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+
+checksum:
+  name_template: checksums.txt
+
+dockers:
+  - id: amd64
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - ghcr.io/gold-kou/prism-in-k8s:{{ .Version }}-amd64
+      - ghcr.io/gold-kou/prism-in-k8s:latest-amd64
+    dockerfile: Dockerfile.release
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.source=https://github.com/gold-kou/prism-in-k8s
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+  - id: arm64
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - ghcr.io/gold-kou/prism-in-k8s:{{ .Version }}-arm64
+      - ghcr.io/gold-kou/prism-in-k8s:latest-arm64
+    dockerfile: Dockerfile.release
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --label=org.opencontainers.image.source=https://github.com/gold-kou/prism-in-k8s
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+
+docker_manifests:
+  - name_template: ghcr.io/gold-kou/prism-in-k8s:{{ .Version }}
+    image_templates:
+      - ghcr.io/gold-kou/prism-in-k8s:{{ .Version }}-amd64
+      - ghcr.io/gold-kou/prism-in-k8s:{{ .Version }}-arm64
+  - name_template: ghcr.io/gold-kou/prism-in-k8s:latest
+    image_templates:
+      - ghcr.io/gold-kou/prism-in-k8s:latest-amd64
+      - ghcr.io/gold-kou/prism-in-k8s:latest-arm64
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "Merge pull request"
+      - "Merge branch"
+
+release:
+  draft: false
+  prerelease: auto

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,5 @@
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY prism-in-k8s /usr/local/bin/prism-in-k8s
+
+ENTRYPOINT ["/usr/local/bin/prism-in-k8s"]

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ clean:
 	rm -f $(BINARY_NAME)
 
 run-create: build
-	PARAMS_CONFIG_PATH=config/params.yaml ./$(BINARY_NAME) -create
+	PARAMS_CONFIG_PATH=config/params.yaml OPENAPI_PATH=app/openapi.yaml ./$(BINARY_NAME) -create
 	$(MAKE) clean
 
 run-create-test: build
-	PARAMS_CONFIG_PATH=config/params.yaml ./$(BINARY_NAME) -create -test
+	PARAMS_CONFIG_PATH=config/params.yaml OPENAPI_PATH=app/openapi.yaml ./$(BINARY_NAME) -create -test
 	$(MAKE) clean
 
 run-delete: build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BINARY_NAME=prism-mock
+BINARY_NAME=prism-in-k8s
 GO=go
 KIND_CLUSTER_NAME=prism-test-cluster
 KIND_CONFIG=kind-config.yaml

--- a/README.md
+++ b/README.md
@@ -12,18 +12,25 @@ By configuring the VirtualService, you can introduce fixed delays using fault in
 # Prerequisites
 Before using this tool, ensure you have the following installed and configured:
 
-- Tools: Go, kubectl, and Docker.
+- Tools: kubectl and Docker.
 - Credentials: Valid AWS and Kubernetes context/credentials.
   - Note: Ensure your current context is set to the target cluster where you want to deploy the mock resources.
 
+# Installation
+Download the binary for your platform from the [GitHub Releases](https://github.com/gold-kou/prism-in-k8s/releases) page. Extract the archive and place the `prism-in-k8s` binary somewhere on your `PATH` (e.g. `/usr/local/bin`).
+
+Alternatively, use the published container image:
+
+```
+ghcr.io/gold-kou/prism-in-k8s:latest
+```
+
 # Usage
 ## Step 1. OpenAPI
-Prepare your OpenAPI definition file. You can either:
-- Place it at `app/openapi.yaml` (default), or
-- Set the `OPENAPI_PATH` environment variable to the path of your OpenAPI file
+Place your OpenAPI definition file at `./openapi.yaml` in your working directory, or set the `OPENAPI_PATH` environment variable to the path of your OpenAPI file.
 
 ## Step 2. Set Parameters
-Define the necessary parameters in `config/params.yaml` and set `PARAMS_CONFIG_PATH` to its path. At a minimum, the following are required:
+Place your parameters file at `./params.yaml` in your working directory, or set the `PARAMS_CONFIG_PATH` environment variable to the path of your parameters file. At a minimum, the following are required:
 
 - `microserviceName`
   - Your microservice name
@@ -34,12 +41,12 @@ Define the necessary parameters in `config/params.yaml` and set `PARAMS_CONFIG_P
 Run the following command to provision the Prism Pod and its associated resources (ECR, Namespace, Deployment, Service, VirtualService):
 
 ```
-$ make run-create
+$ prism-in-k8s -create
 ```
 
 # Cleanup
 ```
-$ make run-delete
+$ prism-in-k8s -delete
 ```
 
 # Parameters
@@ -95,6 +102,18 @@ ecrTags:
 Note: `podAntiAffinityTopologyKey` uses `requiredDuringSchedulingIgnoredDuringExecution` with the `app` label of the deployed service as the label selector. This means it prevents multiple pods of the same Prism mock service from being scheduled on the same topology (e.g., same node).
 
 # For developers
+Additional requirement when building from source:
+
+- Go
+
+## Running from source
+Clone the repository and use the provided Makefile targets, which build the binary locally and pass the in-repo `config/params.yaml` and `app/openapi.yaml` via environment variables:
+
+```
+$ make run-create
+$ make run-delete
+```
+
 ## Testing
 Ensure the following tools are installed before running the tests:
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ Before using this tool, ensure you have the following installed and configured:
 
 # Usage
 ## Step 1. OpenAPI
-Place your OpenAPI definition in `app/openapi.yaml`.
+Prepare your OpenAPI definition file. You can either:
+- Place it at `app/openapi.yaml` (default), or
+- Set the `OPENAPI_PATH` environment variable to the path of your OpenAPI file
 
 ## Step 2. Set Parameters
-Define the necessary parameters in `config/params.yaml`. At a minimum, the following are required:
+Define the necessary parameters in `config/params.yaml` and set `PARAMS_CONFIG_PATH` to its path. At a minimum, the following are required:
 
 - `microserviceName`
   - Your microservice name

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -93,7 +93,7 @@ type ECRTag struct {
 func init() {
 	path := os.Getenv("PARAMS_CONFIG_PATH")
 	if path == "" {
-		log.Fatal("PARAMS_CONFIG_PATH is not set")
+		path = "./params.yaml"
 	}
 	config, err := LoadConfig(path)
 	if err != nil {

--- a/app/registry/buildcontext.go
+++ b/app/registry/buildcontext.go
@@ -1,0 +1,94 @@
+package registry
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const buildContextFileMode fs.FileMode = 0o600
+
+const dockerfile = `FROM stoplight/prism:5.8.2
+COPY openapi.yaml /app/openapi.yaml
+COPY openapi-sample.yaml /app/openapi-sample.yaml
+COPY empty_check_and_copy.sh /app/empty_check_and_copy.sh
+RUN chmod +x /app/empty_check_and_copy.sh && /app/empty_check_and_copy.sh
+CMD ["mock", "-h", "0.0.0.0", "-p", "80", "/app/openapi.yaml"]
+`
+
+const openapiSample = `# https://swagger.io/docs/specification/v3_0/basic-structure/
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in CommonMark or HTML.
+  version: 0.1.9
+
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+
+paths:
+  /users:
+    get:
+      summary: Returns a list of users.
+      description: Optional extended description in CommonMark or HTML.
+      responses:
+        "200":
+          description: A JSON array of user names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+`
+
+const emptyCheckScript = `#!/bin/sh
+
+if [ ! -s /app/openapi.yaml ]; then
+  echo "openapi.yaml is empty or does not exist. Copying openapi-sample.yaml to openapi.yaml."
+  cp /app/openapi-sample.yaml /app/openapi.yaml
+else
+  echo "openapi.yaml is not empty."
+fi
+`
+
+func prepareBuildContext(openapiPath string) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "prism-build-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+
+	cleanup := func() { _ = os.RemoveAll(tmpDir) }
+
+	absOpenAPI, err := filepath.Abs(openapiPath)
+	if err != nil {
+		cleanup()
+		return "", fmt.Errorf("failed to resolve openapi path: %w", err)
+	}
+
+	openapiContent, err := os.ReadFile(absOpenAPI)
+	if err != nil {
+		cleanup()
+		return "", fmt.Errorf("failed to read openapi file %s: %w", absOpenAPI, err)
+	}
+
+	files := map[string][]byte{
+		"Dockerfile":              []byte(dockerfile),
+		"openapi.yaml":            openapiContent,
+		"openapi-sample.yaml":     []byte(openapiSample),
+		"empty_check_and_copy.sh": []byte(emptyCheckScript),
+	}
+
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(tmpDir, name), content, buildContextFileMode); err != nil {
+			cleanup()
+			return "", fmt.Errorf("failed to write %s: %w", name, err)
+		}
+	}
+
+	return tmpDir, nil
+}

--- a/app/registry/buildcontext_test.go
+++ b/app/registry/buildcontext_test.go
@@ -1,0 +1,93 @@
+package registry_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gold-kou/prism-in-k8s/app/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareBuildContext(t *testing.T) {
+	openapiContent := []byte("openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0.0\n")
+	openapiPath := filepath.Join(t.TempDir(), "openapi.yaml")
+	require.NoError(t, os.WriteFile(openapiPath, openapiContent, 0o600))
+
+	buildCtx, err := registry.PrepareBuildContext(openapiPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(buildCtx) })
+
+	expected := map[string][]byte{
+		"Dockerfile":              []byte(registry.Dockerfile),
+		"openapi.yaml":            openapiContent,
+		"openapi-sample.yaml":     []byte(registry.OpenAPISample),
+		"empty_check_and_copy.sh": []byte(registry.EmptyCheckScript),
+	}
+
+	for name, want := range expected {
+		path := filepath.Join(buildCtx, name)
+		got, err := os.ReadFile(path)
+		require.NoErrorf(t, err, "reading %s", name)
+		assert.Equalf(t, want, got, "content of %s", name)
+
+		info, err := os.Stat(path)
+		require.NoErrorf(t, err, "stat %s", name)
+		assert.Equalf(t, registry.BuildContextFileMode, info.Mode().Perm(), "mode of %s", name)
+	}
+}
+
+func TestPrepareBuildContext_RelativePath(t *testing.T) {
+	openapiContent := []byte("openapi: 3.0.0\n")
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "openapi.yaml"), openapiContent, 0o600))
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	buildCtx, err := registry.PrepareBuildContext("openapi.yaml")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(buildCtx) })
+
+	got, err := os.ReadFile(filepath.Join(buildCtx, "openapi.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, openapiContent, got)
+}
+
+func TestPrepareBuildContext_OpenAPIFileNotFound(t *testing.T) {
+	tmpRoot := t.TempDir()
+	t.Setenv("TMPDIR", tmpRoot)
+
+	buildCtx, err := registry.PrepareBuildContext(filepath.Join(tmpRoot, "missing.yaml"))
+
+	assert.Empty(t, buildCtx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read openapi file")
+	assertNoLeakedBuildContext(t, tmpRoot)
+}
+
+func TestPrepareBuildContext_OpenAPIPathIsDirectory(t *testing.T) {
+	tmpRoot := t.TempDir()
+	t.Setenv("TMPDIR", tmpRoot)
+
+	dirAsOpenAPI := filepath.Join(tmpRoot, "openapi-as-dir")
+	require.NoError(t, os.Mkdir(dirAsOpenAPI, 0o700))
+
+	buildCtx, err := registry.PrepareBuildContext(dirAsOpenAPI)
+
+	assert.Empty(t, buildCtx)
+	require.Error(t, err)
+	assertNoLeakedBuildContext(t, tmpRoot)
+}
+
+func assertNoLeakedBuildContext(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContainsf(t, e.Name(), "prism-build-", "leaked temp build context: %s", e.Name())
+	}
+}

--- a/app/registry/ecr.go
+++ b/app/registry/ecr.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -15,10 +16,16 @@ import (
 	"github.com/gold-kou/prism-in-k8s/app/params"
 )
 
-func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, resourceName string) error {
-	// build Docker image
+func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, resourceName, openapiPath string) error {
+	// build Docker image using a temporary build context
+	buildCtx, err := prepareBuildContext(openapiPath)
+	if err != nil {
+		return fmt.Errorf("failed to prepare docker build context: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(buildCtx) }()
+
 	imageTag := params.MicroserviceName + ":v1"
-	cmd := exec.CommandContext(ctx, "docker", "build", "--platform", "linux/amd64", "-f", "Dockerfile.prism", "-t", imageTag, ".")
+	cmd := exec.CommandContext(ctx, "docker", "build", "--platform", "linux/amd64", "-t", imageTag, buildCtx)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to build docker image: %w", err)
 	}
@@ -42,7 +49,7 @@ func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, re
 		RepositoryName: aws.String(repositoryName),
 		Tags:           tags,
 	}
-	_, err := ecrClient.CreateRepository(ctx, input)
+	_, err = ecrClient.CreateRepository(ctx, input)
 	if err != nil {
 		var ecrExistsException *types.RepositoryAlreadyExistsException
 		if !errors.As(err, &ecrExistsException) {

--- a/app/registry/export_test.go
+++ b/app/registry/export_test.go
@@ -1,0 +1,9 @@
+package registry
+
+var (
+	PrepareBuildContext  = prepareBuildContext
+	BuildContextFileMode = buildContextFileMode
+	Dockerfile           = dockerfile
+	OpenAPISample        = openapiSample
+	EmptyCheckScript     = emptyCheckScript
+)

--- a/app/run.go
+++ b/app/run.go
@@ -45,7 +45,7 @@ func init() {
 
 	openapiPath = os.Getenv("OPENAPI_PATH")
 	if openapiPath == "" {
-		openapiPath = "app/openapi.yaml"
+		openapiPath = "./openapi.yaml"
 	}
 
 	if !isTest {

--- a/app/run.go
+++ b/app/run.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -26,6 +27,7 @@ var (
 	kubeConfig    *restclient.Config
 	resourceName  string
 	namespaceName string
+	openapiPath   string
 )
 
 func init() {
@@ -39,6 +41,11 @@ func init() {
 	err := params.ValidateParams()
 	if err != nil {
 		panic(err)
+	}
+
+	openapiPath = os.Getenv("OPENAPI_PATH")
+	if openapiPath == "" {
+		openapiPath = "app/openapi.yaml"
 	}
 
 	if !isTest {
@@ -79,7 +86,7 @@ func Run() {
 
 	if isCreate {
 		if !isTest {
-			err := registry.BuildAndPushECR(ctx, awsConfig, awsAccountID, resourceName)
+			err := registry.BuildAndPushECR(ctx, awsConfig, awsAccountID, resourceName, openapiPath)
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
close https://github.com/gold-kou/prism-in-k8s/issues/22

## Summary
- Add `.goreleaser.yaml` to build cross-platform binaries (linux/darwin x amd64/arm64) and multi-arch Docker images published to `ghcr.io/gold-kou/prism-in-k8s`.
- Add `Dockerfile.release` (distroless base) consumed by GoReleaser.
- Add `.github/workflows/release.yaml` that runs GoReleaser on `v*` tag push, using `GITHUB_TOKEN` for both the Release and GHCR login.
- Release notes are auto-generated from commit history (docs/test/chore/merge commits filtered out).
- Default `OPENAPI_PATH` and `PARAMS_CONFIG_PATH` to `./openapi.yaml` and `./params.yaml` so the released binary works from any working directory.
- Rename the local Makefile build output from `prism-mock` to `prism-in-k8s` so the local and released binary share one name.
- Restructure README into `Installation` / `Usage` for binary users; the `make run-create` flow moves into `For developers > Running from source`.
- Add unit tests for `prepareBuildContext` (happy path + content/mode verification, relative path, missing file, directory-as-path; error paths assert temp build context cleanup).

## Test plan
- [ ] Merge this PR
- [ ] Push a tag like `v0.1.0` and confirm the workflow creates a GitHub Release with archives + checksums and pushes `ghcr.io/gold-kou/prism-in-k8s:v0.1.0` / `:latest`
- [ ] `go test ./app/registry/...` で新規ユニットテストが通ること
- [ ] `make run-create` が新バイナリ名 `prism-in-k8s` で従来通り動くこと
- [ ] 任意ディレクトリで `params.yaml` / `openapi.yaml` を置いて env var なしで `prism-in-k8s -create` が動くこと