### PR TITLE
Document macOS Gatekeeper workaround in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Alternatively, use the published container image:
 ghcr.io/gold-kou/prism-in-k8s:latest
 ```
 
+## macOS users
+The released binary is not signed with an Apple Developer ID, so on first run macOS Gatekeeper may block it with a message like *"Apple could not verify 'prism-in-k8s' is free of malware..."*. Remove the quarantine attribute to allow execution:
+
+```
+xattr -d com.apple.quarantine /path/to/prism-in-k8s
+```
+
+Alternatively, after the block dialog appears, open *System Settings > Privacy & Security* and click *Open Anyway*.
+
 # Usage
 ## Step 1. OpenAPI
 Place your OpenAPI definition file at `./openapi.yaml` in your working directory, or set the `OPENAPI_PATH` environment variable to the path of your OpenAPI file.


### PR DESCRIPTION
## Summary
- Add a "macOS users" subsection under Installation explaining the macOS Gatekeeper block on first run, since the released binary is not signed with an Apple Developer ID.
- Provide two workarounds: removing the quarantine attribute via `xattr -d com.apple.quarantine`, or allowing the binary via *System Settings > Privacy & Security*.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Steps verified on a Mac (Apple Silicon, Sequoia) by downloading the binary and following the documented workaround