### PR TITLE
Make docker build platform configurable via dockerBuildPlatform param

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $ prism-in-k8s -delete
 | `nodeAffinity`                | Node affinity match expressions (key, operator, values). Operators: In, NotIn, Exists, DoesNotExist, Gt, Lt | -                              | No       |
 | `podAntiAffinityTopologyKey`  | Topology key for pod anti-affinity (e.g., `kubernetes.io/hostname`). Prevents multiple pods of the same service from running on the same topology | -                              | No       |
 | `ecrTags`                     | Pairs of ECR tag                          | -                              | No       |
+| `dockerBuildPlatform`         | Target platform passed to `docker build --platform` for the Prism image. Must be `linux/amd64` or `linux/arm64`. Set to `linux/arm64` when the destination cluster runs on Graviton (arm64) nodes. | `linux/amd64`                  | No       |
 
 sample:
 

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -11,13 +11,14 @@ import (
 )
 
 const (
-	defaultTimeout          = 10 * time.Minute
-	defaultPrismPort        = 80
-	defaultPrismCPU         = "500m"
-	defaultPrismMemory      = "512Mi"
-	defaultIstioMode        = false
-	defaultIstioProxyCPU    = "500m"
-	defaultIstioProxyMemory = "512Mi"
+	defaultTimeout             = 10 * time.Minute
+	defaultPrismPort           = 80
+	defaultPrismCPU            = "500m"
+	defaultPrismMemory         = "512Mi"
+	defaultIstioMode           = false
+	defaultIstioProxyCPU       = "500m"
+	defaultIstioProxyMemory    = "512Mi"
+	defaultDockerBuildPlatform = "linux/amd64"
 )
 
 var validNodeSelectorOperators = map[string]bool{
@@ -29,6 +30,11 @@ var validHTTPMethods = map[string]bool{
 	"GET": true, "HEAD": true, "POST": true, "PUT": true,
 	"PATCH": true, "DELETE": true, "CONNECT": true,
 	"OPTIONS": true, "TRACE": true,
+}
+
+var validDockerBuildPlatforms = map[string]bool{
+	"linux/amd64": true,
+	"linux/arm64": true,
 }
 
 const maxDelayPercentage = 100.0
@@ -51,6 +57,7 @@ var (
 	PodAntiAffinityTopologyKey   string
 	EcrTags                      []ECRTag
 	VirtualServiceRoutes         []VirtualServiceRoute
+	DockerBuildPlatform          string
 )
 
 type Config struct {
@@ -69,6 +76,7 @@ type Config struct {
 	PodAntiAffinityTopologyKey   string                        `yaml:"podAntiAffinityTopologyKey"`
 	EcrTags                      []ECRTag                      `yaml:"ecrTags"`
 	VirtualServiceRoutes         []VirtualServiceRoute         `yaml:"virtualServiceRoutes"`
+	DockerBuildPlatform          string                        `yaml:"dockerBuildPlatform"`
 }
 
 type VirtualServiceRoute struct {
@@ -139,6 +147,10 @@ func init() {
 	PodAntiAffinityTopologyKey = config.PodAntiAffinityTopologyKey
 	EcrTags = config.EcrTags
 	VirtualServiceRoutes = config.VirtualServiceRoutes
+	DockerBuildPlatform = defaultDockerBuildPlatform
+	if config.DockerBuildPlatform != "" {
+		DockerBuildPlatform = config.DockerBuildPlatform
+	}
 }
 
 func LoadConfig(filename string) (*Config, error) {
@@ -169,6 +181,7 @@ func ValidateParams() error {
 		"prismMemory":           PrismMemory,
 		"istioProxyCPU":         IstioProxyCPU,
 		"istioProxyMemory":      IstioProxyMemory,
+		"dockerBuildPlatform":   DockerBuildPlatform,
 	}
 
 	for name, value := range params {
@@ -194,6 +207,10 @@ func ValidateParams() error {
 		if !validNodeSelectorOperators[expr.Operator] {
 			return fmt.Errorf("invalid node selector operator: %s", expr.Operator)
 		}
+	}
+
+	if !validDockerBuildPlatforms[DockerBuildPlatform] {
+		return fmt.Errorf("invalid dockerBuildPlatform: %s (must be linux/amd64 or linux/arm64)", DockerBuildPlatform)
 	}
 
 	return validateVirtualServiceRoutes()

--- a/app/registry/ecr.go
+++ b/app/registry/ecr.go
@@ -25,7 +25,7 @@ func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, re
 	defer func() { _ = os.RemoveAll(buildCtx) }()
 
 	imageTag := params.MicroserviceName + ":v1"
-	cmd := exec.CommandContext(ctx, "docker", "build", "--platform", "linux/amd64", "-t", imageTag, buildCtx)
+	cmd := exec.CommandContext(ctx, "docker", "build", "--platform", params.DockerBuildPlatform, "-t", imageTag, buildCtx)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to build docker image: %w", err)
 	}


### PR DESCRIPTION
## Summary
- The hardcoded `--platform linux/amd64` in `BuildAndPushECR` breaks for clusters running on Graviton (arm64) EKS nodes.
- Add an optional `dockerBuildPlatform` parameter (default `linux/amd64`, preserving existing behavior) that can be set in `params.yaml`.
- Restrict the value to `linux/amd64` or `linux/arm64` via an allowlist in `ValidateParams`, matching the existing `validNodeSelectorOperators` / `validHTTPMethods` style. Typos like `linux/amd86` surface as a startup error rather than a confusing docker build failure or an unrunnable image on the cluster.
- Document the parameter in the README parameters table with a note about Graviton clusters.

## Test plan
- [ ] `go build ./...` succeeds
- [ ] `make test-go` passes (existing tests, no behavior change for default path)
- [ ] `golangci-lint run ./...` clean
- [ ] Set `dockerBuildPlatform: "linux/arm64"` in params.yaml and confirm `docker build --platform linux/arm64 ...` is invoked
- [ ] Set `dockerBuildPlatform: "linux/foo"` and confirm the binary panics at startup with the validation error