### PR TITLE
Bump Go to 1.24.13

### DIFF
--- a/app/registry/buildcontext_test.go
+++ b/app/registry/buildcontext_test.go
@@ -43,10 +43,7 @@ func TestPrepareBuildContext_RelativePath(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "openapi.yaml"), openapiContent, 0o600))
 
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(wd) })
+	t.Chdir(dir)
 
 	buildCtx, err := registry.PrepareBuildContext("openapi.yaml")
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gold-kou/prism-in-k8s
 
-go 1.22.5
+go 1.24.13
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.1


### PR DESCRIPTION
## Summary
- Update `go.mod` directive from `go 1.22.5` to `go 1.24.13`. Go 1.22 is past end of support, so security patches have stopped — this moves the project to a currently-supported branch.
- Replace `os.Chdir` with `t.Chdir` in `TestPrepareBuildContext_RelativePath`. `t.Chdir` was added in Go 1.24 and the `usetesting` linter starts requiring it once the `go` directive crosses 1.24.

## Test plan
- [ ] `make test-go` passes
- [ ] `golangci-lint run ./...` clean
- [ ] CI workflows (`actions/setup-go@v5` with `go-version: stable`) build successfully against the new directive