### PR TITLE
Bump kind to v0.31.0 in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.25.0/kind-linux-amd64
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.25.0/kind-linux-amd64
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 


### PR DESCRIPTION
## Summary
- Bump `kind` binary from `v0.25.0` to `v0.31.0` in `.github/workflows/main.yaml` (both the e2e job and the unit-test job).
- v0.31.0 ships Kubernetes 1.35 node images, lining up with the in-flight istio/k8s.io client-go bumps so the test cluster, control-plane API surface, and Go client stay close.

## Test plan
- [ ] CI `setup-and-test-e2e` job succeeds (kind cluster comes up and e2e curl returns 200)
- [ ] CI `setup-and-test-go` job succeeds
