### PR TITLE
Bump GitHub Actions major versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,12 +32,12 @@ jobs:
           sudo mv istio-1.24.0/bin/istioctl /usr/local/bin
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run end-to-end test
         run: |
@@ -62,12 +62,12 @@ jobs:
           sudo mv istio-1.24.0/bin/istioctl /usr/local/bin
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run go tests
         run: |
@@ -78,14 +78,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11
 
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check if openapi.yaml is empty
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 


### PR DESCRIPTION
## Summary
Bump three GitHub Actions to current majors across both workflows:

- `actions/checkout` v4 → v6
- `actions/setup-go` v5 → v6
- `golangci/golangci-lint-action` v7 → v9

The earlier majors run on older Node.js runtimes and emit deprecation warnings in run logs. No config-shape changes are required for these bumps.

## Test plan
- [ ] All CI jobs (`setup-and-test-e2e`, `setup-and-test-go`, `golangci`, `check-openapi-empty`) succeed on this PR
- [ ] On the next tag push, the `release` workflow succeeds with the new actions
