### PR TITLE
Add gitleaks workflow for secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,33 @@
+name: gitleaks
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly full-history scan, every Sunday 00:00 UTC.
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan for leaked secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          # Fetch full history so the weekly scheduled scan can inspect
+          # past commits, not just the most recent one.
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Add `.github/workflows/gitleaks.yaml` to scan for accidentally committed secrets (API keys, tokens, credentials) using `gitleaks/gitleaks-action@v2`.

The workflow runs on:
- **`pull_request` (against main)** — gate new commits before merge.
- **`push` (to main)** — catch direct pushes that bypass PR review.
- **`schedule` (weekly, Sun 00:00 UTC)** — sweep the full commit history for anything earlier checks missed.
- **`workflow_dispatch`** — manual trigger for ad-hoc scans.

`fetch-depth: 0` lets the scheduled run inspect the entire history; for `pull_request` and `push`, the action figures out the diff scope from event metadata.

## Notes
- This repository is public, so `gitleaks-action@v2` runs without `GITLEAKS_LICENSE`. If the repo is later moved into a paid GitHub organization or made private, set `GITLEAKS_LICENSE` as a secret per [the action's docs](https://github.com/gitleaks/gitleaks-action#-license).
- Default rule set is sufficient for now. If it produces false positives (e.g. fixture data), add a repository-level `.gitleaks.toml` with `[allowlist]` rules in a follow-up.
- This adds secret scanning only. Dependency CVEs (Dependabot/govulncheck) and SAST (CodeQL) are separate and not in scope here.

## Test plan
- [ ] Open this PR — gitleaks runs and passes (no secrets in current files or PR diff)
- [ ] Merge — `push` event triggers another run on main
- [ ] Wait for the next Sunday 00:00 UTC, or trigger via `workflow_dispatch` from the Actions tab, to verify the full-history scan succeeds
