### PR TITLE
Remove init() and package-level globals (recreates #55)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ kind-down:
 
 test-go: kind-up
 	@trap '$(MAKE) kind-down' EXIT; \
-	PARAMS_CONFIG_PATH=../../config/params.yaml $(GO) test ./... -v -shuffle=on -p 1
+	$(GO) test ./... -v -shuffle=on -p 1
 
 # use run-create-test to create only k8s resources
 # 2 curl requests because the first one doesn't work

--- a/app/k8s/k8s.go
+++ b/app/k8s/k8s.go
@@ -27,18 +27,18 @@ const (
 	appLabel        = "app"
 )
 
-func CreateK8sResources(ctx context.Context, awsAccountID string, awsConfig aws.Config, kubeconfig *restclient.Config, namespaceName, resourceName string, istioMode, isTest bool) error {
+func CreateK8sResources(ctx context.Context, cfg *params.Config, awsAccountID string, awsConfig aws.Config, kubeconfig *restclient.Config, namespaceName, resourceName string, isTest bool) error {
 	k8sClientSet, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed to create clientset: %w", err)
 	}
 
-	err = createNamespace(ctx, k8sClientSet, namespaceName, istioMode)
+	err = createNamespace(ctx, k8sClientSet, namespaceName, cfg.IstioMode)
 	if err != nil {
 		return fmt.Errorf("failed to create namespace: %w", err)
 	}
 
-	err = createDeployment(ctx, awsAccountID, awsConfig, k8sClientSet, namespaceName, resourceName, istioMode, isTest)
+	err = createDeployment(ctx, cfg, k8sClientSet, awsAccountID, awsConfig, namespaceName, resourceName, isTest)
 	if err != nil {
 		return fmt.Errorf("failed to create deployment: %w", err)
 	}
@@ -91,7 +91,7 @@ func createNamespace(ctx context.Context, k8sClientSet *kubernetes.Clientset, na
 	return nil
 }
 
-func createDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Config, k8sClientSet *kubernetes.Clientset, namespaceName, resourceName string, istioMode, isTest bool) error {
+func createDeployment(ctx context.Context, cfg *params.Config, k8sClientSet *kubernetes.Clientset, awsAccountID string, awsConfig aws.Config, namespaceName, resourceName string, isTest bool) error {
 	// Prism image
 	prismImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", awsAccountID, awsConfig.Region, resourceName)
 	if isTest {
@@ -124,34 +124,34 @@ func createDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Co
 							Image: prismImage,
 							Ports: []corev1.ContainerPort{
 								{
-									ContainerPort: int32(params.PrismPort),
+									ContainerPort: int32(cfg.PrismPort),
 								},
 							},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse(params.PrismCPU),
-									corev1.ResourceMemory: resource.MustParse(params.PrismMemory),
+									corev1.ResourceCPU:    resource.MustParse(cfg.PrismCPU),
+									corev1.ResourceMemory: resource.MustParse(cfg.PrismMemory),
 								},
 							},
 						},
 					},
-					PriorityClassName: params.PriorityClassName,
+					PriorityClassName: cfg.PriorityClassName,
 				},
 			},
 		},
 	}
 
-	deployment.Spec.Template.Spec.Affinity = buildAffinity(resourceName)
+	deployment.Spec.Template.Spec.Affinity = buildAffinity(cfg, resourceName)
 
 	if isTest {
 		// to get image from local
 		deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullNever
 	}
 
-	if istioMode {
+	if cfg.IstioMode {
 		deployment.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"] = "true"
-		deployment.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/proxyCPULimit"] = params.IstioProxyCPU
-		deployment.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/proxyMemoryLimit"] = params.IstioProxyMemory
+		deployment.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/proxyCPULimit"] = cfg.IstioProxyCPU
+		deployment.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/proxyMemoryLimit"] = cfg.IstioProxyMemory
 		deployment.Spec.Template.ObjectMeta.Annotations["traffic.sidecar.istio.io/includeOutboundIPRanges"] = "*"
 		deployment.Spec.Template.ObjectMeta.Annotations["proxy.istio.io/config"] = `{ "terminationDrainDuration": "30s" }`
 	}
@@ -168,9 +168,9 @@ func createDeployment(ctx context.Context, awsAccountID string, awsConfig aws.Co
 	return nil
 }
 
-func buildAffinity(resourceName string) *corev1.Affinity {
-	hasNodeAffinity := len(params.NodeAffinityMatchExpressions) > 0
-	hasPodAntiAffinity := params.PodAntiAffinityTopologyKey != ""
+func buildAffinity(cfg *params.Config, resourceName string) *corev1.Affinity {
+	hasNodeAffinity := len(cfg.NodeAffinityMatchExpressions) > 0
+	hasPodAntiAffinity := cfg.PodAntiAffinityTopologyKey != ""
 
 	if !hasNodeAffinity && !hasPodAntiAffinity {
 		return nil
@@ -179,8 +179,8 @@ func buildAffinity(resourceName string) *corev1.Affinity {
 	affinity := &corev1.Affinity{}
 
 	if hasNodeAffinity {
-		matchExpressions := make([]corev1.NodeSelectorRequirement, 0, len(params.NodeAffinityMatchExpressions))
-		for _, expr := range params.NodeAffinityMatchExpressions {
+		matchExpressions := make([]corev1.NodeSelectorRequirement, 0, len(cfg.NodeAffinityMatchExpressions))
+		for _, expr := range cfg.NodeAffinityMatchExpressions {
 			matchExpressions = append(matchExpressions, corev1.NodeSelectorRequirement{
 				Key:      expr.Key,
 				Operator: corev1.NodeSelectorOperator(expr.Operator),
@@ -211,7 +211,7 @@ func buildAffinity(resourceName string) *corev1.Affinity {
 							},
 						},
 					},
-					TopologyKey: params.PodAntiAffinityTopologyKey,
+					TopologyKey: cfg.PodAntiAffinityTopologyKey,
 				},
 			},
 		}

--- a/app/k8s/k8s_test.go
+++ b/app/k8s/k8s_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/gold-kou/prism-in-k8s/app/k8s"
+	"github.com/gold-kou/prism-in-k8s/app/params"
 	"github.com/gold-kou/prism-in-k8s/app/testutil"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -27,8 +28,15 @@ func TestCreateK8sResources(t *testing.T) {
 	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	require.NoError(t, err)
 
+	cfg := &params.Config{
+		MicroserviceName:      testResourceName,
+		MicroserviceNamespace: testNamespaceName,
+		IstioMode:             true,
+	}
+	cfg.ApplyDefaults()
+
 	// test target
-	err = k8s.CreateK8sResources(ctx, dummyAWSAccountID, awsConfig, kubeconfig, testNamespaceName, testResourceName, true, true)
+	err = k8s.CreateK8sResources(ctx, cfg, dummyAWSAccountID, awsConfig, kubeconfig, testNamespaceName, testResourceName, true)
 	require.NoError(t, err)
 
 	// verify

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -3,7 +3,6 @@ package params
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"time"
 
@@ -15,10 +14,10 @@ const (
 	defaultPrismPort           = 80
 	defaultPrismCPU            = "500m"
 	defaultPrismMemory         = "512Mi"
-	defaultIstioMode           = false
 	defaultIstioProxyCPU       = "500m"
 	defaultIstioProxyMemory    = "512Mi"
 	defaultDockerBuildPlatform = "linux/amd64"
+	maxDelayPercentage         = 100.0
 )
 
 var validNodeSelectorOperators = map[string]bool{
@@ -36,29 +35,6 @@ var validDockerBuildPlatforms = map[string]bool{
 	"linux/amd64": true,
 	"linux/arm64": true,
 }
-
-const maxDelayPercentage = 100.0
-
-var (
-	// required parameters
-	MicroserviceName      string
-	MicroserviceNamespace string
-	PrismMockSuffix       string
-	// optional parameters
-	Timeout                      time.Duration
-	PrismPort                    int
-	PrismCPU                     string
-	PrismMemory                  string
-	IstioMode                    bool
-	IstioProxyCPU                string
-	IstioProxyMemory             string
-	PriorityClassName            string
-	NodeAffinityMatchExpressions []NodeAffinityMatchExpression
-	PodAntiAffinityTopologyKey   string
-	EcrTags                      []ECRTag
-	VirtualServiceRoutes         []VirtualServiceRoute
-	DockerBuildPlatform          string
-)
 
 type Config struct {
 	MicroserviceName             string                        `yaml:"microserviceName"`
@@ -98,61 +74,6 @@ type ECRTag struct {
 	Value string `yaml:"value"`
 }
 
-func init() {
-	path := os.Getenv("PARAMS_CONFIG_PATH")
-	if path == "" {
-		path = "./params.yaml"
-	}
-	config, err := LoadConfig(path)
-	if err != nil {
-		log.Fatalf("Error loading config: %v", err)
-	}
-
-	// required parameters
-	MicroserviceName = config.MicroserviceName
-	MicroserviceNamespace = config.MicroserviceNamespace
-	PrismMockSuffix = config.PrismMockSuffix
-
-	// optional parameters
-	Timeout = defaultTimeout
-	if config.Timeout != 0 {
-		Timeout = config.Timeout
-	}
-	PrismPort = defaultPrismPort
-	if config.PrismPort != 0 {
-		PrismPort = config.PrismPort
-	}
-	PrismCPU = defaultPrismCPU
-	if config.PrismCPU != "" {
-		PrismCPU = config.PrismCPU
-	}
-	PrismMemory = defaultPrismMemory
-	if config.PrismMemory != "" {
-		PrismMemory = config.PrismMemory
-	}
-	IstioMode = defaultIstioMode
-	if config.IstioMode {
-		IstioMode = config.IstioMode
-	}
-	IstioProxyCPU = defaultIstioProxyCPU
-	if config.IstioProxyCPU != "" {
-		IstioProxyCPU = config.IstioProxyCPU
-	}
-	IstioProxyMemory = defaultIstioProxyMemory
-	if config.IstioProxyMemory != "" {
-		IstioProxyMemory = config.IstioProxyMemory
-	}
-	PriorityClassName = config.PriorityClassName
-	NodeAffinityMatchExpressions = config.NodeAffinityMatchExpressions
-	PodAntiAffinityTopologyKey = config.PodAntiAffinityTopologyKey
-	EcrTags = config.EcrTags
-	VirtualServiceRoutes = config.VirtualServiceRoutes
-	DockerBuildPlatform = defaultDockerBuildPlatform
-	if config.DockerBuildPlatform != "" {
-		DockerBuildPlatform = config.DockerBuildPlatform
-	}
-}
-
 func LoadConfig(filename string) (*Config, error) {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -160,76 +81,82 @@ func LoadConfig(filename string) (*Config, error) {
 	}
 	defer file.Close()
 
-	var config Config
+	var cfg Config
 	decoder := yaml.NewDecoder(file)
-	if err := decoder.Decode(&config); err != nil {
+	if err := decoder.Decode(&cfg); err != nil {
 		// this error includes type mismatching error
 		return nil, fmt.Errorf("failed to decode config file: %w", err)
 	}
 
-	return &config, nil
+	cfg.ApplyDefaults()
+	return &cfg, nil
 }
 
-func ValidateParams() error {
-	params := map[string]interface{}{
-		"microserviceName":      MicroserviceName,
-		"microserviceNamespace": MicroserviceNamespace,
-		"prismMockSuffix":       PrismMockSuffix,
-		"timeout":               Timeout,
-		"prismPort":             PrismPort,
-		"prismCPU":              PrismCPU,
-		"prismMemory":           PrismMemory,
-		"istioProxyCPU":         IstioProxyCPU,
-		"istioProxyMemory":      IstioProxyMemory,
-		"dockerBuildPlatform":   DockerBuildPlatform,
+func (c *Config) ApplyDefaults() {
+	if c.Timeout == 0 {
+		c.Timeout = defaultTimeout
 	}
+	if c.PrismPort == 0 {
+		c.PrismPort = defaultPrismPort
+	}
+	if c.PrismCPU == "" {
+		c.PrismCPU = defaultPrismCPU
+	}
+	if c.PrismMemory == "" {
+		c.PrismMemory = defaultPrismMemory
+	}
+	if c.IstioProxyCPU == "" {
+		c.IstioProxyCPU = defaultIstioProxyCPU
+	}
+	if c.IstioProxyMemory == "" {
+		c.IstioProxyMemory = defaultIstioProxyMemory
+	}
+	if c.DockerBuildPlatform == "" {
+		c.DockerBuildPlatform = defaultDockerBuildPlatform
+	}
+}
 
-	for name, value := range params {
-		switch v := value.(type) {
-		case string:
-			if v == "" {
-				return fmt.Errorf("empty parameter found: %s", name)
-			}
-		case int:
-			if v == 0 {
-				return fmt.Errorf("empty parameter found: %s", name)
-			}
-		case time.Duration:
-			if v == 0*time.Millisecond {
-				return fmt.Errorf("empty parameter found: %s", name)
-			}
-		default:
-			return fmt.Errorf("unsupported parameter type: %s", name)
+func (c *Config) Validate() error {
+	c.ApplyDefaults()
+
+	requiredStrings := map[string]string{
+		"microserviceName":      c.MicroserviceName,
+		"microserviceNamespace": c.MicroserviceNamespace,
+		"prismMockSuffix":       c.PrismMockSuffix,
+	}
+	for name, v := range requiredStrings {
+		if v == "" {
+			return fmt.Errorf("empty parameter found: %s", name)
 		}
 	}
 
-	for _, expr := range NodeAffinityMatchExpressions {
+	for _, expr := range c.NodeAffinityMatchExpressions {
 		if !validNodeSelectorOperators[expr.Operator] {
 			return fmt.Errorf("invalid node selector operator: %s", expr.Operator)
 		}
 	}
 
-	if !validDockerBuildPlatforms[DockerBuildPlatform] {
-		return fmt.Errorf("invalid dockerBuildPlatform: %s (must be linux/amd64 or linux/arm64)", DockerBuildPlatform)
+	if !validDockerBuildPlatforms[c.DockerBuildPlatform] {
+		return fmt.Errorf("invalid dockerBuildPlatform: %s (must be linux/amd64 or linux/arm64)", c.DockerBuildPlatform)
 	}
 
-	return validateVirtualServiceRoutes()
+	return c.validateVirtualServiceRoutes()
 }
 
-func validateVirtualServiceRoutes() error {
-	if len(VirtualServiceRoutes) > 0 && !IstioMode {
+func (c *Config) validateVirtualServiceRoutes() error {
+	if len(c.VirtualServiceRoutes) > 0 && !c.IstioMode {
 		return errors.New("virtualServiceRoutes can only be set when istioMode is true")
 	}
 
-	seenRouteNames := make(map[string]struct{}, len(VirtualServiceRoutes))
-	for i, route := range VirtualServiceRoutes {
+	seen := make(map[string]struct{}, len(c.VirtualServiceRoutes))
+	for i, route := range c.VirtualServiceRoutes {
 		if route.Name == "" {
 			return fmt.Errorf("empty parameter found: virtualServiceRoutes[%d].name", i)
 		}
-		if _, ok := seenRouteNames[route.Name]; ok {
+		if _, ok := seen[route.Name]; ok {
 			return fmt.Errorf("duplicate virtualServiceRoutes name: %s", route.Name)
 		}
-		seenRouteNames[route.Name] = struct{}{}
+		seen[route.Name] = struct{}{}
 		if route.Method != "" && !validHTTPMethods[route.Method] {
 			return fmt.Errorf("virtualServiceRoutes[%d].method is invalid HTTP method: %s", i, route.Method)
 		}

--- a/app/registry/ecr.go
+++ b/app/registry/ecr.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gold-kou/prism-in-k8s/app/params"
 )
 
-func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, resourceName, openapiPath string) error {
+func BuildAndPushECR(ctx context.Context, cfg *params.Config, awsConfig aws.Config, awsAccountID, resourceName, openapiPath string) error {
 	// build Docker image using a temporary build context
 	buildCtx, err := prepareBuildContext(openapiPath)
 	if err != nil {
@@ -24,8 +24,8 @@ func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, re
 	}
 	defer func() { _ = os.RemoveAll(buildCtx) }()
 
-	imageTag := params.MicroserviceName + ":v1"
-	cmd := exec.CommandContext(ctx, "docker", "build", "--platform", params.DockerBuildPlatform, "-t", imageTag, buildCtx)
+	imageTag := cfg.MicroserviceName + ":v1"
+	cmd := exec.CommandContext(ctx, "docker", "build", "--platform", cfg.DockerBuildPlatform, "-t", imageTag, buildCtx)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to build docker image: %w", err)
 	}
@@ -33,7 +33,7 @@ func BuildAndPushECR(ctx context.Context, awsConfig aws.Config, awsAccountID, re
 
 	// ECR tags
 	tags := []types.Tag{}
-	for _, ecrTag := range params.EcrTags {
+	for _, ecrTag := range cfg.EcrTags {
 		if ecrTag.Key != "" || ecrTag.Value != "" {
 			tags = append(tags, types.Tag{
 				Key:   aws.String(ecrTag.Key),

--- a/app/run.go
+++ b/app/run.go
@@ -2,10 +2,8 @@ package app
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -18,109 +16,86 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var (
-	isCreate      bool
-	isDelete      bool
-	isTest        bool
-	awsConfig     aws.Config
-	awsAccountID  string
-	kubeConfig    *restclient.Config
-	resourceName  string
-	namespaceName string
-	openapiPath   string
-)
+type App struct {
+	Config        *params.Config
+	OpenAPIPath   string
+	IsTest        bool
+	AWSConfig     aws.Config
+	AWSAccountID  string
+	KubeConfig    *restclient.Config
+	ResourceName  string
+	NamespaceName string
+}
 
-func init() {
-	// command args
-	flag.BoolVar(&isCreate, "create", false, "set to true if running in create mode")
-	flag.BoolVar(&isDelete, "delete", false, "set to true if running in delete mode")
-	flag.BoolVar(&isTest, "test", false, "set to true if running in test mode")
-	flag.Parse()
-
-	// validation parameters
-	err := params.ValidateParams()
-	if err != nil {
-		panic(err)
-	}
-
-	openapiPath = os.Getenv("OPENAPI_PATH")
-	if openapiPath == "" {
-		openapiPath = "./openapi.yaml"
+func NewApp(ctx context.Context, cfg *params.Config, openapiPath string, isTest bool) (*App, error) {
+	a := &App{
+		Config:        cfg,
+		OpenAPIPath:   openapiPath,
+		IsTest:        isTest,
+		ResourceName:  cfg.MicroserviceName + cfg.PrismMockSuffix,
+		NamespaceName: cfg.MicroserviceNamespace + cfg.PrismMockSuffix,
 	}
 
 	if !isTest {
-		// AWS config
-		awsConfig, err = config.LoadDefaultConfig(context.Background())
+		awsCfg, err := config.LoadDefaultConfig(ctx)
 		if err != nil {
-			panic(fmt.Errorf("failed to load AWS config: %w", err))
+			return nil, fmt.Errorf("failed to load AWS config: %w", err)
 		}
-
-		// get AWS account ID
-		stsClient := sts.NewFromConfig(awsConfig)
-		result, err := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
+		stsClient := sts.NewFromConfig(awsCfg)
+		result, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 		if err != nil {
-			panic(fmt.Errorf("failed to get caller identity: %w", err))
+			return nil, fmt.Errorf("failed to get caller identity: %w", err)
 		}
-		awsAccountID = *result.Account
+		a.AWSConfig = awsCfg
+		a.AWSAccountID = *result.Account
 	}
 
-	// kube config
 	kubeconfigPath := clientcmd.NewDefaultPathOptions().GetDefaultFilename()
-	kubeConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	kubeCfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
-		panic(fmt.Errorf("failed to build Kubeconfig: %w", err))
+		return nil, fmt.Errorf("failed to build Kubeconfig: %w", err)
 	}
+	a.KubeConfig = kubeCfg
 
-	// resource name
-	resourceName = "test-microservice"
-	namespaceName = "test-namespace"
-	if params.MicroserviceName != "" && params.MicroserviceNamespace != "" {
-		resourceName = params.MicroserviceName + params.PrismMockSuffix
-		namespaceName = params.MicroserviceNamespace + params.PrismMockSuffix
-	}
+	return a, nil
 }
 
-func Run() {
-	ctx, cancel := context.WithTimeout(context.Background(), params.Timeout)
-	defer cancel()
-
-	if isCreate {
-		if !isTest {
-			err := registry.BuildAndPushECR(ctx, awsConfig, awsAccountID, resourceName, openapiPath)
-			if err != nil {
-				panic(err)
-			}
+func (a *App) Create(ctx context.Context) error {
+	if !a.IsTest {
+		if err := registry.BuildAndPushECR(ctx, a.Config, a.AWSConfig, a.AWSAccountID, a.ResourceName, a.OpenAPIPath); err != nil {
+			return fmt.Errorf("ECR build/push failed: %w", err)
 		}
-
-		err := k8s.CreateK8sResources(ctx, awsAccountID, awsConfig, kubeConfig, namespaceName, resourceName, params.IstioMode, isTest)
-		if err != nil {
-			panic(err)
-		}
-
-		if params.IstioMode {
-			err = istio.CreateIstioResources(ctx, kubeConfig, namespaceName, resourceName, params.VirtualServiceRoutes)
-			if err != nil {
-				panic(err)
-			}
-		}
-		slog.Info("All resources for prism mock are created successfully")
-	} else if isDelete {
-		if params.IstioMode {
-			err := istio.DeleteIstioResources(ctx, kubeConfig, namespaceName, resourceName)
-			if err != nil {
-				panic(err)
-			}
-		}
-
-		err := k8s.DeleteK8sResources(ctx, kubeConfig, namespaceName, resourceName)
-		if err != nil {
-			panic(err)
-		}
-
-		err = registry.DeleteECR(ctx, awsConfig, resourceName)
-		if err != nil {
-			panic(err)
-		}
-		slog.Info("All resources for prism mock are deleted successfully")
 	}
+
+	if err := k8s.CreateK8sResources(ctx, a.Config, a.AWSAccountID, a.AWSConfig, a.KubeConfig, a.NamespaceName, a.ResourceName, a.IsTest); err != nil {
+		return fmt.Errorf("k8s resource creation failed: %w", err)
+	}
+
+	if a.Config.IstioMode {
+		if err := istio.CreateIstioResources(ctx, a.KubeConfig, a.NamespaceName, a.ResourceName, a.Config.VirtualServiceRoutes); err != nil {
+			return fmt.Errorf("istio resource creation failed: %w", err)
+		}
+	}
+
+	slog.Info("All resources for prism mock are created successfully")
+	return nil
+}
+
+func (a *App) Delete(ctx context.Context) error {
+	if a.Config.IstioMode {
+		if err := istio.DeleteIstioResources(ctx, a.KubeConfig, a.NamespaceName, a.ResourceName); err != nil {
+			return fmt.Errorf("istio resource deletion failed: %w", err)
+		}
+	}
+
+	if err := k8s.DeleteK8sResources(ctx, a.KubeConfig, a.NamespaceName, a.ResourceName); err != nil {
+		return fmt.Errorf("k8s resource deletion failed: %w", err)
+	}
+
+	if err := registry.DeleteECR(ctx, a.AWSConfig, a.ResourceName); err != nil {
+		return fmt.Errorf("ECR deletion failed: %w", err)
+	}
+
+	slog.Info("All resources for prism mock are deleted successfully")
+	return nil
 }

--- a/app/run.go
+++ b/app/run.go
@@ -36,6 +36,7 @@ func NewApp(ctx context.Context, cfg *params.Config, openapiPath string, isTest 
 		NamespaceName: cfg.MicroserviceNamespace + cfg.PrismMockSuffix,
 	}
 
+	// if test, don't load aws config
 	if !isTest {
 		awsCfg, err := config.LoadDefaultConfig(ctx)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,62 @@
 package main
 
-import "github.com/gold-kou/prism-in-k8s/app"
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/gold-kou/prism-in-k8s/app"
+	"github.com/gold-kou/prism-in-k8s/app/params"
+)
 
 func main() {
-	app.Run()
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	isCreate := flag.Bool("create", false, "set to true if running in create mode")
+	isDelete := flag.Bool("delete", false, "set to true if running in delete mode")
+	isTest := flag.Bool("test", false, "set to true if running in test mode")
+	flag.Parse()
+
+	paramsPath := os.Getenv("PARAMS_CONFIG_PATH")
+	if paramsPath == "" {
+		paramsPath = "./params.yaml"
+	}
+	cfg, err := params.LoadConfig(paramsPath)
+	if err != nil {
+		return fmt.Errorf("failed to load params: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid params: %w", err)
+	}
+
+	openapiPath := os.Getenv("OPENAPI_PATH")
+	if openapiPath == "" {
+		openapiPath = "./openapi.yaml"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
+	defer cancel()
+
+	a, err := app.NewApp(ctx, cfg, openapiPath, *isTest)
+	if err != nil {
+		return fmt.Errorf("failed to initialize app: %w", err)
+	}
+
+	switch {
+	case *isCreate:
+		if err := a.Create(ctx); err != nil {
+			return fmt.Errorf("create failed: %w", err)
+		}
+	case *isDelete:
+		if err := a.Delete(ctx); err != nil {
+			return fmt.Errorf("delete failed: %w", err)
+		}
+	}
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -18,11 +18,13 @@ func main() {
 }
 
 func run() error {
+	// flag input
 	isCreate := flag.Bool("create", false, "set to true if running in create mode")
 	isDelete := flag.Bool("delete", false, "set to true if running in delete mode")
 	isTest := flag.Bool("test", false, "set to true if running in test mode")
 	flag.Parse()
 
+	// config input
 	paramsPath := os.Getenv("PARAMS_CONFIG_PATH")
 	if paramsPath == "" {
 		paramsPath = "./params.yaml"
@@ -35,6 +37,7 @@ func run() error {
 		return fmt.Errorf("invalid params: %w", err)
 	}
 
+	// openapi input
 	openapiPath := os.Getenv("OPENAPI_PATH")
 	if openapiPath == "" {
 		openapiPath = "./openapi.yaml"


### PR DESCRIPTION
Recreates the closed #55 from current main. Same goal, fresh diff.

## Problem

Three issues with the previous structure:

1. **`params.init()` fataled at import time** when `PARAMS_CONFIG_PATH` was unset, so any test or tool that transitively imported the params package needed that env var even if it had nothing to do with config loading. This is why `make test-go` had to set `PARAMS_CONFIG_PATH=../../config/params.yaml` and why I had to do the same dance when running `prepareBuildContext` tests.
2. **State was held in package-level variables** with no clean way to construct a `Config` in tests, or to load multiple configs in any future feature.
3. **`app/run.go`'s `init()`** likewise loaded AWS, kubeconfig, and parsed flags at import time, with no way to skip or substitute them.

## Changes

- **`app/params/params.go`** — Remove `init()` and all package-level globals. Move parsing, defaults, and validation onto the `Config` type:
  - `LoadConfig(path) (*Config, error)` parses yaml and applies defaults.
  - `(*Config).ApplyDefaults()` is idempotent; `(*Config).Validate()` calls it so callers do not have to remember the order.
- **`app/run.go`** — Replace `init()` + globals with an `App` struct:
  - `NewApp(ctx, cfg, openapiPath, isTest)` loads AWS (when `!isTest`) and kubeconfig.
  - `(*App).Create(ctx)` and `(*App).Delete(ctx)` replace the old monolithic `Run()`.
- **`main.go`** — Owns flag parsing, env-var resolution, `LoadConfig`/`Validate`, and the `App` lifecycle. The error path is a single top-level `os.Exit(1)` so `defer cancel()` runs.
- **`app/k8s/k8s.go`, `app/registry/ecr.go`** — Take `*params.Config` explicitly instead of reading globals. Inner helpers (`createDeployment`, `buildAffinity`) take it through.
- **`app/k8s/k8s_test.go`** — Constructs its own `*params.Config` instead of relying on a package-init read of `../../config/params.yaml`.
- **`Makefile`** — `test-go` no longer sets `PARAMS_CONFIG_PATH`. `run-create` / `run-delete` still set it because `main.go` reads it.

## Notes

- Public API surface that callers see: `params.LoadConfig`, `(*Config).ApplyDefaults`, `(*Config).Validate`, `app.NewApp`, `(*App).Create`, `(*App).Delete`. Everything else stays unexported.
- No new tests in this PR; that becomes much easier as a follow-up now that `Config` is constructible without env vars.
- Closes the work originally proposed in #55 (which was 67 commits behind and unrebasable).

## Test plan
- [ ] `go build ./...` succeeds (verified locally)
- [ ] `go vet ./...` clean (verified locally)
- [ ] `golangci-lint run ./...` clean (verified locally)
- [ ] `make test-go` passes — should now run without `PARAMS_CONFIG_PATH` env var
- [ ] `make test-e2e` passes — verifies the runtime path through `NewApp` → `Create`
- [ ] Local manual smoke: `prism-in-k8s -create -test` from a working dir with `params.yaml` and `openapi.yaml` produces the same k8s resources as before
