### PR TITLE
Fix misleading defaults for required params in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,48 +67,48 @@ $ prism-in-k8s -delete
 | `microserviceName`            | Name of microservice                      | -                              | Yes      |
 | `microserviceNamespace`       | Namespace of microservice                 | -                              | Yes      |
 | `prismMockSuffix`             | Suffix for the mock service name          | -                              | Yes      |
-| `timeout`                     | Timeout for this tool                     | `10m`                          | No       |
+| `timeout`                     | Timeout for this tool                     | `"10m"`                        | No       |
 | `prismPort`                   | Port number for Prism                     | `80`                           | No       |
-| `prismCpu`                    | CPU request for Prism                     | `500m`                         | No       |
-| `prismMemory`                 | Memory request for Prism                  | `512Mi`                        | No       |
+| `prismCpu`                    | CPU request for Prism                     | `"500m"`                       | No       |
+| `prismMemory`                 | Memory request for Prism                  | `"512Mi"`                      | No       |
 | `istioMode`                   | Whether to use istio                      | `false`                        | No       |
 | `virtualServiceRoutes`        | HTTP routes for the Istio VirtualService. Each entry supports `name` (required), `uriPrefix`, `method` (GET/HEAD/POST/PUT/PATCH/DELETE/CONNECT/OPTIONS/TRACE), `delayNanos` (>=0), and `delayPercentage` (0-100). A trailing catch-all `default` route is appended automatically. Only applied when `istioMode` is `true`. | -                              | No       |
-| `istioProxyCpu`               | CPU request for Istio                     | `500m`                         | No       |
-| `istioProxyMemory`            | Memory request for Istio                  | `512Mi`                        | No       |
+| `istioProxyCpu`               | CPU request for Istio                     | `"500m"`                       | No       |
+| `istioProxyMemory`            | Memory request for Istio                  | `"512Mi"`                      | No       |
 | `priorityClassName`           | Value of priorityClassName                | -                              | No       |
 | `nodeAffinity`                | Node affinity match expressions (key, operator, values). Operators: In, NotIn, Exists, DoesNotExist, Gt, Lt | -                              | No       |
 | `podAntiAffinityTopologyKey`  | Topology key for pod anti-affinity (e.g., `kubernetes.io/hostname`). Prevents multiple pods of the same service from running on the same topology | -                              | No       |
 | `ecrTags`                     | Pairs of ECR tag                          | -                              | No       |
-| `dockerBuildPlatform`         | Target platform passed to `docker build --platform` for the Prism image. Must be `linux/amd64` or `linux/arm64`. Set to `linux/arm64` when the destination cluster runs on Graviton (arm64) nodes. | `linux/amd64`                  | No       |
+| `dockerBuildPlatform`         | Target platform passed to `docker build --platform` for the Prism image. Must be `linux/amd64` or `linux/arm64`. Set to `linux/arm64` when the destination cluster runs on Graviton (arm64) nodes. | `"linux/amd64"`                | No       |
 
 sample:
 
 ```
-microserviceName: sample
-microserviceNamespace: sample
-prismMockSuffix: -prism-mock
+microserviceName: "sample"
+microserviceNamespace: "sample"
+prismMockSuffix: "-prism-mock"
 istioMode: true
 virtualServiceRoutes:
-  - name: example1
-    uriPrefix: /example1/
-    method: GET
+  - name: "example1"
+    uriPrefix: "/example1/"
+    method: "GET"
     delayNanos: 100000000
     delayPercentage: 100
-  - name: example2
-    uriPrefix: /example2/
-    method: POST
-priorityClassName: high-priority
+  - name: "example2"
+    uriPrefix: "/example2/"
+    method: "POST"
+priorityClassName: "high-priority"
 nodeAffinity:
-  - key: karpenter.sh/nodepool
-    operator: In
+  - key: "karpenter.sh/nodepool"
+    operator: "In"
     values:
-      - default
-podAntiAffinityTopologyKey: kubernetes.io/hostname
+      - "default"
+podAntiAffinityTopologyKey: "kubernetes.io/hostname"
 ecrTags:
-  - key: CostEnv
-    value: stg
-  - key: CostService
-    value: pet-store
+  - key: "CostEnv"
+    value: "stg"
+  - key: "CostService"
+    value: "pet-store"
 ```
 
 Note: `podAntiAffinityTopologyKey` uses `requiredDuringSchedulingIgnoredDuringExecution` with the `app` label of the deployed service as the label selector. This means it prevents multiple pods of the same Prism mock service from being scheduled on the same topology (e.g., same node).

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ $ prism-in-k8s -delete
 
 | Parameter Name                | Description                               | Default                        | Required |
 |-------------------------------|-------------------------------------------|--------------------------------|----------|
-| `microserviceName`            | Name of microservice                      | `sample`                       | Yes      |
-| `microserviceNamespace`       | Namespace of microservice                 | `sample`                       | Yes      |
-| `prismMockSuffix`             | Suffix for the mock service name          | `"-prism-mock"`                | Yes      |
+| `microserviceName`            | Name of microservice                      | -                              | Yes      |
+| `microserviceNamespace`       | Namespace of microservice                 | -                              | Yes      |
+| `prismMockSuffix`             | Suffix for the mock service name          | -                              | Yes      |
 | `timeout`                     | Timeout for this tool                     | `10m`                          | No       |
 | `prismPort`                   | Port number for Prism                     | `80`                           | No       |
 | `prismCpu`                    | CPU request for Prism                     | `"500m"`                       | No       |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Place your parameters file at `./params.yaml` in your working directory, or set 
   - Your microservice name
 - `microserviceNamespace`
   - Your microservice namespace
+- `prismMockSuffix`
+  - Suffix appended to the microservice name/namespace to form the mock Service and Namespace names (e.g. `-prism-mock`)
 
 ## Step 3. Deploy Mock Resources
 Run the following command to provision the Prism Pod and its associated resources (ECR, Namespace, Deployment, Service, VirtualService):

--- a/README.md
+++ b/README.md
@@ -84,31 +84,31 @@ $ prism-in-k8s -delete
 sample:
 
 ```
-microserviceName: "sample"
-microserviceNamespace: "sample"
-prismMockSuffix: "-prism-mock"
+microserviceName: sample
+microserviceNamespace: sample
+prismMockSuffix: -prism-mock
 istioMode: true
 virtualServiceRoutes:
-  - name: "example1"
-    uriPrefix: "/example1/"
-    method: "GET"
+  - name: example1
+    uriPrefix: /example1/
+    method: GET
     delayNanos: 100000000
     delayPercentage: 100
-  - name: "example2"
-    uriPrefix: "/example2/"
-    method: "POST"
-priorityClassName: "high-priority"
+  - name: example2
+    uriPrefix: /example2/
+    method: POST
+priorityClassName: high-priority
 nodeAffinity:
-  - key: "karpenter.sh/nodepool"
-    operator: "In"
+  - key: karpenter.sh/nodepool
+    operator: In
     values:
-      - "default"
-podAntiAffinityTopologyKey: "kubernetes.io/hostname"
+      - default
+podAntiAffinityTopologyKey: kubernetes.io/hostname
 ecrTags:
-  - key: "CostEnv"
-    value: "stg"
-  - key: "CostService"
-    value: "pet-store"
+  - key: CostEnv
+    value: stg
+  - key: CostService
+    value: pet-store
 ```
 
 Note: `podAntiAffinityTopologyKey` uses `requiredDuringSchedulingIgnoredDuringExecution` with the `app` label of the deployed service as the label selector. This means it prevents multiple pods of the same Prism mock service from being scheduled on the same topology (e.g., same node).

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ $ prism-in-k8s -delete
 | `prismMockSuffix`             | Suffix for the mock service name          | -                              | Yes      |
 | `timeout`                     | Timeout for this tool                     | `10m`                          | No       |
 | `prismPort`                   | Port number for Prism                     | `80`                           | No       |
-| `prismCpu`                    | CPU request for Prism                     | `"500m"`                       | No       |
-| `prismMemory`                 | Memory request for Prism                  | `"512Mi"`                      | No       |
+| `prismCpu`                    | CPU request for Prism                     | `500m`                         | No       |
+| `prismMemory`                 | Memory request for Prism                  | `512Mi`                        | No       |
 | `istioMode`                   | Whether to use istio                      | `false`                        | No       |
 | `virtualServiceRoutes`        | HTTP routes for the Istio VirtualService. Each entry supports `name` (required), `uriPrefix`, `method` (GET/HEAD/POST/PUT/PATCH/DELETE/CONNECT/OPTIONS/TRACE), `delayNanos` (>=0), and `delayPercentage` (0-100). A trailing catch-all `default` route is appended automatically. Only applied when `istioMode` is `true`. | -                              | No       |
-| `istioProxyCpu`               | CPU request for Istio                     | `"500m"`                       | No       |
-| `istioProxyMemory`            | Memory request for Istio                  | `"512Mi"`                      | No       |
+| `istioProxyCpu`               | CPU request for Istio                     | `500m`                         | No       |
+| `istioProxyMemory`            | Memory request for Istio                  | `512Mi`                        | No       |
 | `priorityClassName`           | Value of priorityClassName                | -                              | No       |
 | `nodeAffinity`                | Node affinity match expressions (key, operator, values). Operators: In, NotIn, Exists, DoesNotExist, Gt, Lt | -                              | No       |
 | `podAntiAffinityTopologyKey`  | Topology key for pod anti-affinity (e.g., `kubernetes.io/hostname`). Prevents multiple pods of the same service from running on the same topology | -                              | No       |


### PR DESCRIPTION
## Summary
`microserviceName`, `microserviceNamespace`, and `prismMockSuffix` are required and have no built-in defaults — `Validate()` rejects empty values. The README's Parameters table showed `sample`, `sample`, and `"-prism-mock"` in the Default column, but those are the values used in the example `config/params.yaml`, not actual code defaults. The table also marks the same three rows as `Required: Yes`, which is internally inconsistent.

Replace those three Default entries with `-` to match the other required-with-no-default fields in the same table.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] No code change, so existing CI jobs are unaffected
